### PR TITLE
Fix edit controller meta

### DIFF
--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -413,6 +413,8 @@ const PostEdit = () => (
 
 {% endraw %}
 
+**Warning**: If you set `mutationOptions` meta without [redirecting](#redirect), make sure that [`queryOptions`](#queryoptions) meta is the same, or you will have data update issues.
+
 You can also use `mutationOptions` to override success or error side effects, by setting the `mutationOptions` prop. Refer to the [useMutation documentation](https://tanstack.com/query/v5/docs/react/reference/useMutation) in the react-query website for a list of the possible options.
 
 Let's see an example with the success side effect. By default, when the save action succeeds, react-admin shows a notification, and redirects to the list page. You can override this behavior and pass custom success side effects by providing a `mutationOptions` prop with an `onSuccess` key:
@@ -561,6 +563,8 @@ export const PostShow = () => (
 
 {% endraw %}
 
+**Warning**: If you set `queryOptions` meta without [redirecting](#redirect), make sure that [`mutationOptions`](#mutationoptions) meta is the same, or you will have data update issues.
+
 You can also use `queryOptions` to force a refetch on reconnect:
 
 {% raw %}
@@ -597,6 +601,8 @@ const PostEdit = () => (
 ```
 
 Note that the `redirect` prop is ignored if you set [the `mutationOptions` prop](#mutationoptions). See that prop for how to set a different redirection path in that case.
+
+**Warning**: If you set [`queryOptions`](#queryoptions) meta without redirecting, make sure that [`mutationOptions`](#mutationoptions) meta is the same, or you will have data update issues.
 
 ## `render`
 

--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -600,7 +600,7 @@ const PostEdit = () => (
 );
 ```
 
-Note that the `redirect` prop is ignored if you set [the `mutationOptions` prop](#mutationoptions). See that prop for how to set a different redirection path in that case.
+Note that the `redirect` prop is ignored if you set an `onSuccess` callback of [the `mutationOptions` prop](#mutationoptions). See that prop for how to set a different redirection path in that case.
 
 **Warning**: If you set [`queryOptions`](#queryoptions) meta without redirecting, make sure that [`mutationOptions`](#mutationoptions) meta is the same, or you will have data update issues.
 

--- a/packages/ra-core/src/controller/edit/useEditController.spec.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.spec.tsx
@@ -217,6 +217,35 @@ describe('useEditController', () => {
         });
     });
 
+    it('should emit a warning when providing a different meta in query options and mutation options without redirecting', async () => {
+        const warnFn = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+        const getOne = jest
+            .fn()
+            .mockImplementationOnce(() =>
+                Promise.resolve({ data: { id: 0, title: 'hello' } })
+            );
+        const dataProvider = { getOne } as unknown as DataProvider;
+
+        render(
+            <CoreAdminContext dataProvider={dataProvider}>
+                <EditController
+                    {...defaultProps}
+                    resource="posts"
+                    queryOptions={{ meta: { foo: 'bar' } }}
+                    mutationOptions={{ meta: { foo: 'baz' } }}
+                    redirect={false}
+                >
+                    {() => <div />}
+                </EditController>
+            </CoreAdminContext>
+        );
+
+        expect(warnFn).toHaveBeenCalledWith(
+            'When not redirecting after editing, query meta and mutation meta should be the same, or you will have data update issues.'
+        );
+    });
+
     it('should call the dataProvider.update() function on save', async () => {
         const update = jest
             .fn()

--- a/packages/ra-core/src/controller/edit/useEditController.stories.tsx
+++ b/packages/ra-core/src/controller/edit/useEditController.stories.tsx
@@ -75,6 +75,40 @@ export const EncodedIdWithPercentage = ({
     );
 };
 
+export const WarningLogWithDifferentMeta = () => (
+    <TestMemoryRouter initialEntries={['/posts/5']}>
+        <CoreAdminContext
+            dataProvider={testDataProvider({
+                getOne: (_resource, { id }) =>
+                    Promise.resolve({
+                        data: { id, title: 'hello' } as any,
+                    }),
+            })}
+        >
+            <Routes>
+                <Route
+                    path="/posts/:id"
+                    element={
+                        <EditController
+                            resource="posts"
+                            queryOptions={{ meta: { foo: 'bar' } }}
+                            redirect={false}
+                        >
+                            {({ record }) => (
+                                <>
+                                    <LocationInspector />
+                                    <p>Id: {record && record.id}</p>
+                                    <p>Title: {record && record.title}</p>
+                                </>
+                            )}
+                        </EditController>
+                    }
+                />
+            </Routes>
+        </CoreAdminContext>
+    </TestMemoryRouter>
+);
+
 const LocationInspector = () => {
     const location = useLocation();
     return (

--- a/packages/ra-core/src/controller/edit/useEditController.ts
+++ b/packages/ra-core/src/controller/edit/useEditController.ts
@@ -89,6 +89,7 @@ export const useEditController = <
         );
     }
     const id = propsId ?? routeId;
+
     const { meta: queryMeta, ...otherQueryOptions } = queryOptions;
     const {
         meta: mutationMeta,
@@ -96,6 +97,17 @@ export const useEditController = <
         onError,
         ...otherMutationOptions
     } = mutationOptions;
+
+    if (
+        (queryMeta || mutationMeta) &&
+        JSON.stringify(queryMeta) !== JSON.stringify(mutationMeta) &&
+        redirectTo === false
+    ) {
+        console.warn(
+            'When not redirecting after editing, query meta and mutation meta should be the same, or you will have data update issues.'
+        );
+    }
+
     const {
         registerMutationMiddleware,
         getMutateWithMiddlewares,
@@ -302,6 +314,7 @@ export interface EditControllerProps<
     redirect?: RedirectionSideEffect;
     resource?: string;
     transform?: TransformData;
+
     [key: string]: any;
 }
 
@@ -322,6 +335,7 @@ export interface EditControllerLoadingResult<RecordType extends RaRecord = any>
     error: null;
     isPending: true;
 }
+
 export interface EditControllerLoadingErrorResult<
     RecordType extends RaRecord = any,
     TError = Error,
@@ -330,6 +344,7 @@ export interface EditControllerLoadingErrorResult<
     error: TError;
     isPending: false;
 }
+
 export interface EditControllerRefetchErrorResult<
     RecordType extends RaRecord = any,
     TError = Error,
@@ -338,6 +353,7 @@ export interface EditControllerRefetchErrorResult<
     error: TError;
     isPending: false;
 }
+
 export interface EditControllerSuccessResult<RecordType extends RaRecord = any>
     extends EditControllerBaseResult<RecordType> {
     record: RecordType;


### PR DESCRIPTION
## Problem

When providing a meta in the `queryOption` of an `<Edit>`, users must also provide it to the same `mutationOptions`. Otherwise, when disabling the redirection to the list, they might end up with the data not being updated correctly.

## Solution

1. Documentation
2. Add a console log to warn the user when they use different meta in query options / mutation options and redirect false

## How To Test

Story

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date
