### PR TITLE
Support ReactNode as create label

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -57,25 +57,25 @@ The form value for the source must be an array of the selected values, e.g.
 
 ## Props
 
-| Prop                       | Required | Type                  | Default                  | Description                                                                                                                                                                                                                                                                                                      |
-|----------------------------|----------|-----------------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `choices`                  | Required | `Object[]`            | -                        | List of choices                                                   |
-| `create`                   | Optional | `Element`             | `-`                      | A React Element to render when users want to create a new choice                                                                       |
-| `createLabel`              | Optional | `string`              | -                        | The label used as hint to let users know they can create a new choice. Displayed when the filter is empty.                                       |
-| `createItemLabel`          | Optional | `string`              | `ra.action .create_item` | The label for the menu item allowing users to create a new choice. Used when the filter is not empty.                                                    |
-| `debounce`                 | Optional | `number`              | `250`                    | The delay to wait before calling the setFilter function injected when used in a ReferenceArray Input.                                                         |
-| `emptyValue`               | Optional | `any`                 | `''`                     | The value to use for the empty element                                                                                                                  |
-| `filterToQuery`            | Optional | `string` => `Object`  | `q => ({ q })`           | How to transform the searchText into a parameter for the data provider                                                                                  |
-| `inputText`                | Optional | `Function`            | `-`                      | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                 |
-| `matchSuggestion`          | Optional | `Function`            | `-`                      | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
-| `onChange`                 | Optional | `Function`            | `-`                      | A function called with the new value, along with the selected records, when the input value changes |
-| `onCreate`                 | Optional | `Function`            | `-`                      | A function called with the current filter value when users choose to create a new choice.                                                               |
-| `optionText`               | Optional | `string` &#124; `Function` &#124; `Component` | `name` | Field name of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`)           |
-| `optionValue`              | Optional | `string`              | `id`                     | Field name of record containing the value to use as input value                                                                                         |
-| `setFilter`                | Optional | `Function`            | `null`                   | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically set up when using `ReferenceArray Input`. |
-| `shouldRender Suggestions` | Optional | `Function`            | `() => true`             | A function that returns a `boolean` to determine whether or not suggestions are rendered.  |
-| `suggestionLimit`          | Optional | `number`              | `null`                   | Limits the numbers of suggestions that are shown in the dropdown list                                                                                   |
-| `translateChoice` | Optional | `boolean`                  | `true`             | Whether the choices should be translated                                                                                               |
+| Prop                       | Required | Type                                            | Default                  | Description                                                                                                                                                                                                                                                                                                      |
+|----------------------------|----------|-------------------------------------------------|--------------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `choices`                  | Required | `Object[]`                                      | -                        | List of choices                                                   |
+| `create`                   | Optional | `Element`                                       | `-`                      | A React Element to render when users want to create a new choice                                                                       |
+| `createLabel`              | Optional | `string` &#124; `ReactNode`                     | -                        | The label used as hint to let users know they can create a new choice. Displayed when the filter is empty.                                       |
+| `createItemLabel`          | Optional | `string` &#124; `(filter: string) => ReactNode` | `ra.action .create_item` | The label for the menu item allowing users to create a new choice. Used when the filter is not empty.                                                    |
+| `debounce`                 | Optional | `number`                                        | `250`                    | The delay to wait before calling the setFilter function injected when used in a ReferenceArray Input.                                                         |
+| `emptyValue`               | Optional | `any`                                           | `''`                     | The value to use for the empty element                                                                                                                  |
+| `filterToQuery`            | Optional | `string` => `Object`                            | `q => ({ q })`           | How to transform the searchText into a parameter for the data provider                                                                                  |
+| `inputText`                | Optional | `Function`                                      | `-`                      | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                 |
+| `matchSuggestion`          | Optional | `Function`                                      | `-`                      | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
+| `onChange`                 | Optional | `Function`                                      | `-`                      | A function called with the new value, along with the selected records, when the input value changes |
+| `onCreate`                 | Optional | `Function`                                      | `-`                      | A function called with the current filter value when users choose to create a new choice.                                                               |
+| `optionText`               | Optional | `string` &#124; `Function` &#124; `Component`   | `name` | Field name of record to display in the suggestion item or function which accepts the correct record as argument (`(record)=> {string}`)           |
+| `optionValue`              | Optional | `string`                                        | `id`                     | Field name of record containing the value to use as input value                                                                                         |
+| `setFilter`                | Optional | `Function`                                      | `null`                   | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically set up when using `ReferenceArray Input`. |
+| `shouldRender Suggestions` | Optional | `Function`                                      | `() => true`             | A function that returns a `boolean` to determine whether or not suggestions are rendered.  |
+| `suggestionLimit`          | Optional | `number`                                        | `null`                   | Limits the numbers of suggestions that are shown in the dropdown list                                                                                   |
+| `translateChoice` | Optional | `boolean`                                       | `true`             | Whether the choices should be translated                                                                                               |
 
 
 `<AutocompleteArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
@@ -236,6 +236,21 @@ You can use the `createLabel` prop to render an additional (disabled) menu item 
 />
 ```
 
+You can also use any React node as the create label.
+
+```jsx
+<AutocompleteArrayInput
+    source="roles"
+    choices={choices}
+    create={<CreateRole />}
+    createLabel={
+        <Typography className="custom">
+            Start typing to create a new <strong>role</strong>
+        </Typography>
+    }
+/>
+```
+
 ## `createItemLabel`
 
 If you set the `create` or `onCreate` prop, `<AutocompleteArrayInput>` lets users create new options. When the text entered by the user doesn't match any option, the input renders a "Create XXX" menu item at the bottom of the list.
@@ -250,6 +265,21 @@ Or, if you want to customize it just for this `<AutocompleteArrayInput>`, use th
     choices={choices}
     create={<CreateRole />}
     createItemLabel="Add a new role: %{item}"
+/>
+```
+
+You can also define a function returning any rendered React node.
+
+```jsx
+<AutocompleteArrayInput
+    source="roles"
+    choices={choices}
+    create={<CreateRole />}
+    createItemLabel={item => (
+        <Typography className="custom">
+            Create <Chip label={item} />
+        </Typography>
+    )}
 />
 ```
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -54,27 +54,27 @@ The form value for the source must be the selected value, e.g.
 
 ## Props
 
-| Prop                       | Required | Type                  | Default                                                             | Description                                                                                                                                                                                                         |
-|--------------------------- |----------|---------------------- |---------------------------------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `choices`                  | Optional | `Object[]`            | `-`                                                                 | List of items to autosuggest. Required if not inside a ReferenceInput.                                                                                                                                              |
-| `create`                   | Optional | `Element`             | `-`                                                                 | A React Element to render when users want to create a new choice                                                                                                                                                    |
-| `createLabel`              | Optional | `string`              | -                                                                   | The label used as hint to let users know they can create a new choice. Displayed when the filter is empty.                                                                                                                    |
-| `createItemLabel`          | Optional | `string`              | `ra.action .create_item`                                            | The label for the menu item allowing users to create a new choice. Used when the filter is not empty.                                                                                                                |
-| `debounce`                 | Optional | `number`              | `250`                                                               | The delay to wait before calling the setFilter function injected when used in a ReferenceInput.                                                                                                                     |
-| `emptyText`                | Optional | `string`              | `''`                                                                | The text to use for the empty element                                                                                                                                                                               |
-| `emptyValue`               | Optional | `any`                 | `''`                                                                | The value to use for the empty element                                                                                                                                                                              |
-| `filterToQuery`            | Optional | `string` => `Object`  | `q => ({ q })`                                                      | How to transform the searchText into a parameter for the data provider                                                                                                                                              |
-| `isPending`                | Optional | `boolean`             | `false`                                                             | If `true`, the component will display a loading indicator.                                                                                                                                                          |
-| `inputText`                | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
-| `matchSuggestion`          | Optional | `Function`            | `-`                                                                 | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
-| `onChange`                 | Optional | `Function`            | `-`                                                                 | A function called with the new value, along with the selected record, when the input value changes |
-| `onCreate`                 | Optional | `Function`            | `-`                                                                 | A function called with the current filter value when users choose to create a new choice.                                                                                                                           |
-| `optionText`               | Optional | `string` &#124; `Function` &#124; `Component` |  `undefined` &#124; `record Representation` | Field name of record to display in the suggestion item or function using the choice object as argument                                                                                                              |
-| `optionValue`              | Optional | `string`              | `id`                                                                | Field name of record containing the value to use as input value                                                                                                                                                     |
-| `setFilter`                | Optional | `Function`            | `null`                                                              | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically set up when using `ReferenceInput`. |
-| `shouldRender Suggestions` | Optional | `Function`            | `() => true`                                                        | A function that returns a `boolean` to determine whether or not suggestions are rendered.                                                                                                                           |
-| `suggestionLimit`          | Optional | `number`              | `null`                                                              | Limits the numbers of suggestions that are shown in the dropdown list                                                                                                                                               |
-| `translateChoice`          | Optional | `boolean`             | `true`                                                              | Whether the choices should be translated                                                                                                                                                                            |
+| Prop                       | Required | Type                                            | Default                                   | Description                                                                                                                                                                                                         |
+|--------------------------- |----------|-------------------------------------------------|-------------------------------------------|---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `choices`                  | Optional | `Object[]`                                      | `-`                                       | List of items to autosuggest. Required if not inside a ReferenceInput.                                                                                                                                              |
+| `create`                   | Optional | `Element`                                       | `-`                                       | A React Element to render when users want to create a new choice                                                                                                                                                    |
+| `createLabel`              | Optional | `string` &#124; `ReactNode`                     | -                                                                   | The label used as hint to let users know they can create a new choice. Displayed when the filter is empty.                                                                                                                    |
+| `createItemLabel`          | Optional | `string` &#124; `(filter: string) => ReactNode` | `ra.action .create_item`                                            | The label for the menu item allowing users to create a new choice. Used when the filter is not empty.                                                                                                                |
+| `debounce`                 | Optional | `number`                                        | `250`                                     | The delay to wait before calling the setFilter function injected when used in a ReferenceInput.                                                                                                                     |
+| `emptyText`                | Optional | `string`                                        | `''`                                      | The text to use for the empty element                                                                                                                                                                               |
+| `emptyValue`               | Optional | `any`                                           | `''`                                      | The value to use for the empty element                                                                                                                                                                              |
+| `filterToQuery`            | Optional | `string` => `Object`                            | `q => ({ q })`                            | How to transform the searchText into a parameter for the data provider                                                                                                                                              |
+| `isPending`                | Optional | `boolean`                                       | `false`                                   | If `true`, the component will display a loading indicator.                                                                                                                                                          |
+| `inputText`                | Optional | `Function`                                      | `-`                                       | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
+| `matchSuggestion`          | Optional | `Function`                                      | `-`                                       | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
+| `onChange`                 | Optional | `Function`                                      | `-`                                       | A function called with the new value, along with the selected record, when the input value changes |
+| `onCreate`                 | Optional | `Function`                                      | `-`                                       | A function called with the current filter value when users choose to create a new choice.                                                                                                                           |
+| `optionText`               | Optional | `string` &#124; `Function` &#124; `Component`   | `undefined` &#124; `record Representation` | Field name of record to display in the suggestion item or function using the choice object as argument                                                                                                              |
+| `optionValue`              | Optional | `string`                                        | `id`                                      | Field name of record containing the value to use as input value                                                                                                                                                     |
+| `setFilter`                | Optional | `Function`                                      | `null`                                    | A callback to inform the `searchText` has changed and new `choices` can be retrieved based on this `searchText`. Signature `searchText => void`. This function is automatically set up when using `ReferenceInput`. |
+| `shouldRender Suggestions` | Optional | `Function`                                      | `() => true`                              | A function that returns a `boolean` to determine whether or not suggestions are rendered.                                                                                                                           |
+| `suggestionLimit`          | Optional | `number`                                        | `null`                                    | Limits the numbers of suggestions that are shown in the dropdown list                                                                                                                                               |
+| `translateChoice`          | Optional | `boolean`                                       | `true`                                    | Whether the choices should be translated                                                                                                                                                                            |
 
 `<AutocompleteInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -241,6 +241,21 @@ You can use the `createLabel` prop to render an additional (disabled) menu item 
 />
 ```
 
+You can also use any React node as the create label.
+
+```jsx
+<AutocompleteInput
+    source="author"
+    choices={authors}
+    onCreate={onCreate}
+    createLabel={
+        <Typography className="custom">
+            Start typing to create a new <strong>author</strong>
+        </Typography>
+    }
+/>
+```
+
 ## `createItemLabel`
 
 If you set the `create` or `onCreate` prop, `<AutocompleteInput>` lets users create new options. When the text entered by the user doesn't match any option, the input renders a "Create XXX" menu item at the bottom of the list.
@@ -257,6 +272,21 @@ Or, if you want to customize it just for this `<AutocompleteInput>`, use the `cr
     choices={authors}
     onCreate={onCreate}
     createItemLabel="Add a new author: %{item}"
+/>
+```
+
+You can also define a function returning any rendered React node.
+
+```jsx
+<AutocompleteInput
+    source="author"
+    choices={authors}
+    onCreate={onCreate}
+    createItemLabel={item => (
+        <Typography className="custom">
+            Create <Chip label={item} />
+        </Typography>
+    )}
 />
 ```
 

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -61,18 +61,18 @@ The form value for the source must be an array of the selected values, e.g.
 
 ## Props
 
-| Prop              | Required | Type                       | Default               | Description                                                                                                                            |
-|-------------------|----------|----------------------------|---------------   -----|----------------------------------------------------------------------------------------------------------------------------------------|
-| `choices`         | Optional | `Object[]`                 | -                     | List of items to show as options. Required unless inside a ReferenceArray Input.                                                       |
-| `create`          | Optional | `Element`                  | -                     | A React Element to render when users want to create a new choice                                                                       |
-| `createLabel`     | Optional | `string`                   | `ra.action. create`   | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
-| `disableValue`    | Optional | `string`                   | 'disabled'            | The custom field name used in `choices` to disable some choices                                                                        |
-| `InputLabelProps` | Optional | `Object`                   | -                     | Props to pass to the underlying `<InputLabel>` element                                                                                 |
-| `onCreate`        | Optional | `Function`                 | -                     | A function called with the current filter value when users choose to create a new choice.                                              |
-| `options`         | Optional | `Object`                   | -                     | Props to pass to the underlying `<SelectInput>` element                                                                                |
-| `optionText`      | Optional | `string` &#124; `Function` | `name`                | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
-| `optionValue`     | Optional | `string`                   | `id`                  | Field name of record containing the value to use as input value                                                                        |
-| `translateChoice` | Optional | `boolean`                  | `true`                | Whether the choices should be translated                                                                                               |
+| Prop              | Required | Type                        | Default             | Description                                                                                                                            |
+|-------------------|----------|-----------------------------|---------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `choices`         | Optional | `Object[]`                  | -                   | List of items to show as options. Required unless inside a ReferenceArray Input.                                                       |
+| `create`          | Optional | `Element`                   | -                   | A React Element to render when users want to create a new choice                                                                       |
+| `createLabel`     | Optional | `string` &#124; `ReactNode` | `ra.action. create` | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
+| `disableValue`    | Optional | `string`                    | 'disabled'          | The custom field name used in `choices` to disable some choices                                                                        |
+| `InputLabelProps` | Optional | `Object`                    | -                   | Props to pass to the underlying `<InputLabel>` element                                                                                 |
+| `onCreate`        | Optional | `Function`                  | -                   | A function called with the current filter value when users choose to create a new choice.                                              |
+| `options`         | Optional | `Object`                    | -                   | Props to pass to the underlying `<SelectInput>` element                                                                                |
+| `optionText`      | Optional | `string` &#124; `Function`  | `name`              | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
+| `optionValue`     | Optional | `string`                    | `id`                | Field name of record containing the value to use as input value                                                                        |
+| `translateChoice` | Optional | `boolean`                   | `true`              | Whether the choices should be translated                                                                                               |
 
 `<SelectArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -237,6 +237,21 @@ Or, if you want to customize it just for this `<SelectArrayInput>`, use the `cre
     choices={choices}
     create={<CreateRole />}
     createLabel="Add a new role"
+/>
+```
+
+You can also use any React node as the create label.
+
+```jsx
+<SelectArrayInput
+    source="roles"
+    choices={choices}
+    create={<CreateRole />}
+    createLabel={
+        <Typography className="custom">
+            Add a new <strong>role</strong>
+        </Typography>
+    }
 />
 ```
 

--- a/docs/SelectInput.md
+++ b/docs/SelectInput.md
@@ -56,20 +56,20 @@ The form value for the source must be the selected value, e.g.
 
 ## Props
 
-| Prop              | Required | Type                       | Default            | Description                                                                                                                            |
-|-------------------|----------|----------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `choices`         | Optional | `Object[]`                 | -                  | List of items to show as options. Required unless inside a ReferenceInput.                                                             |
-| `create`          | Optional | `Element`                  | `-`                | A React Element to render when users want to create a new choice                                                                       |
-| `createLabel`     | Optional | `string`                   | `ra.action.create` | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
-| `disableValue`    | Optional | `string`                   | 'disabled'         | The custom field name used in `choices` to disable some choices                                                                        |
-| `emptyText`       | Optional | `string`                   | ''                 | The text to display for the empty option                                                                                               |
-| `emptyValue`      | Optional | `any`                      | ''                 | The value to use for the empty option                                                                                                  |
-| `isPending`       | Optional | `boolean`                  | `false`            | If `true`, the component will display a loading indicator.                                                                             |
-| `onCreate`        | Optional | `Function`                 | `-`                | A function called with the current filter value when users choose to create a new choice.                                              |
+| Prop              | Required | Type                                      | Default            | Description                                                                                                                            |
+|-------------------|----------|-------------------------------------------|--------------------|----------------------------------------------------------------------------------------------------------------------------------------|
+| `choices`         | Optional | `Object[]`                                | -                  | List of items to show as options. Required unless inside a ReferenceInput.                                                             |
+| `create`          | Optional | `Element`                                 | `-`                | A React Element to render when users want to create a new choice                                                                       |
+| `createLabel`     | Optional | `string` &#124; `ReactNode`               | `ra.action.create` | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
+| `disableValue`    | Optional | `string`                                  | 'disabled'         | The custom field name used in `choices` to disable some choices                                                                        |
+| `emptyText`       | Optional | `string`                                  | ''                 | The text to display for the empty option                                                                                               |
+| `emptyValue`      | Optional | `any`                                     | ''                 | The value to use for the empty option                                                                                                  |
+| `isPending`       | Optional | `boolean`                                 | `false`            | If `true`, the component will display a loading indicator.                                                                             |
+| `onCreate`        | Optional | `Function`                                | `-`                | A function called with the current filter value when users choose to create a new choice.                                              |
 | `optionText`      | Optional | `string` &#124; `Function` &#124; `Component` | `undefined` &#124; `record Representation` | Field name of record to display in the suggestion item or function using the choice object as argument |
-| `optionValue`     | Optional | `string`                   | `id`               | Field name of record containing the value to use as input value                                                                        |
-| `resettable`      | Optional | `boolean`                  | `false`            | If `true`, display a button to reset the changes in this input value                                                                   |
-| `translateChoice` | Optional | `boolean`                  | `true`             | Whether the choices should be translated                                                                                               |
+| `optionValue`     | Optional | `string`                                  | `id`               | Field name of record containing the value to use as input value                                                                        |
+| `resettable`      | Optional | `boolean`                                 | `false`            | If `true`, display a button to reset the changes in this input value                                                                   |
+| `translateChoice` | Optional | `boolean`                                 | `true`             | Whether the choices should be translated                                                                                               |
 
 `<SelectInput>` also accepts the [common input props](./Inputs.md#common-input-props).
 
@@ -242,6 +242,21 @@ Or, if you want to customize it just for this `<SelectInput>`, use the `createLa
     choices={categories}
     onCreate={onCreate}
     createLabel="Add a new category"
+/>
+```
+
+You can also use any React node as the create label.
+
+```jsx
+<SelectInput
+    source="category"
+    choices={categories}
+    onCreate={onCreate}
+    createLabel={
+        <Typography className="custom">
+            Add a new <strong>category</strong>
+        </Typography>
+    }
 />
 ```
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.spec.tsx
@@ -14,6 +14,7 @@ import { AutocompleteArrayInput } from './AutocompleteArrayInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
 import {
     CreateItemLabel,
+    CreateItemLabelRendered,
     CreateLabel,
     InsideReferenceArrayInput,
     InsideReferenceArrayInputOnChange,
@@ -1289,4 +1290,40 @@ describe('<AutocompleteArrayInput />', () => {
         });
         expect(screen.getByDisplayValue('French')).not.toBeNull();
     });
+
+    it('should allow to pass rendered createLabel and createItemLabel', async () => {
+        render(<CreateItemLabelRendered />);
+
+        const input = await screen.findByRole('combobox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '' } });
+
+        expect((await screen.findByTestId('new-role-hint')).textContent).toBe(
+            'Start typing to create a new role'
+        );
+
+        fireEvent.change(input, { target: { value: 'Guest' } });
+
+        expect((await screen.findByTestId('new-role-chip')).textContent).toBe(
+            'Guest'
+        );
+    });
+    it('should not use the rendered createItemLabel as the value of the input', async () => {
+        render(<CreateItemLabelRendered />);
+        const input = (await screen.findByLabelText('Roles', undefined, {
+            timeout: 2000,
+        })) as HTMLInputElement;
+        await waitFor(() => {
+            expect(input.value).toBe('');
+        });
+        fireEvent.focus(input);
+        expect(screen.getAllByRole('option')).toHaveLength(3);
+        fireEvent.change(input, { target: { value: 'x' } });
+        await waitFor(() => {
+            expect(screen.getAllByRole('option')).toHaveLength(1);
+        });
+        fireEvent.click(screen.getByText('Create'));
+        expect(input.value).not.toBe('Create x');
+        expect(input.value).toBe('');
+    }, 10000);
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteArrayInput.stories.tsx
@@ -4,12 +4,14 @@ import { Admin } from 'react-admin';
 import CloseIcon from '@mui/icons-material/Close';
 import {
     Button,
+    Chip,
     Dialog,
     DialogActions,
     DialogContent,
     DialogTitle,
     IconButton,
     TextField,
+    Typography,
 } from '@mui/material';
 
 import {
@@ -311,6 +313,27 @@ export const CreateItemLabel = () => (
             sx={{ width: 400 }}
             create={<CreateRole />}
             createItemLabel="Add a new role: %{item}"
+        />
+    </Wrapper>
+);
+
+export const CreateItemLabelRendered = () => (
+    <Wrapper>
+        <AutocompleteArrayInput
+            source="roles"
+            choices={choices}
+            sx={{ width: 400 }}
+            create={<CreateRole />}
+            createLabel={
+                <Typography data-testid="new-role-hint">
+                    Start typing to create a new <strong>role</strong>
+                </Typography>
+            }
+            createItemLabel={item => (
+                <Typography component="div">
+                    Create <Chip label={item} data-testid="new-role-chip" />
+                </Typography>
+            )}
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -29,6 +29,7 @@ import {
     OnCreateSlow,
     CreateLabel,
     CreateItemLabel,
+    CreateItemLabelRendered,
 } from './AutocompleteInput.stories';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
@@ -1989,4 +1990,40 @@ describe('<AutocompleteInput />', () => {
             screen.getByText('Victor Hugo');
         });
     });
+
+    it('should allow to pass rendered createLabel and createItemLabel', async () => {
+        render(<CreateItemLabelRendered />);
+
+        const input = await screen.findByRole('combobox');
+        fireEvent.focus(input);
+        fireEvent.change(input, { target: { value: '' } });
+
+        expect((await screen.findByTestId('new-choice-hint')).textContent).toBe(
+            'Start typing to create a new author'
+        );
+
+        fireEvent.change(input, { target: { value: 'Gustave Flaubert' } });
+
+        expect((await screen.findByTestId('new-choice-chip')).textContent).toBe(
+            'Gustave Flaubert'
+        );
+    });
+    it('should not use the rendered createItemLabel as the value of the input', async () => {
+        render(<CreateItemLabelRendered delay={1500} />);
+        const input = (await screen.findByLabelText('Author', undefined, {
+            timeout: 2000,
+        })) as HTMLInputElement;
+        await waitFor(() => {
+            expect(input.value).toBe('Leo Tolstoy');
+        });
+        fireEvent.focus(input);
+        expect(screen.getAllByRole('option')).toHaveLength(4);
+        fireEvent.change(input, { target: { value: 'x' } });
+        await waitFor(() => {
+            expect(screen.getAllByRole('option')).toHaveLength(1);
+        });
+        fireEvent.click(screen.getByText('Create'));
+        expect(input.value).not.toBe('Create x');
+        expect(input.value).toBe('');
+    }, 10000);
 });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -19,6 +19,7 @@ import ExpandCircleDownIcon from '@mui/icons-material/ExpandCircleDown';
 import {
     Box,
     Button,
+    Chip,
     Dialog,
     DialogActions,
     DialogContent,
@@ -41,6 +42,7 @@ import { AutocompleteInput, AutocompleteInputProps } from './AutocompleteInput';
 import { ReferenceInput } from './ReferenceInput';
 import { TextInput } from './TextInput';
 import { useCreateSuggestionContext } from './useSupportCreateSuggestion';
+import { delayedDataProvider } from './common';
 
 export default { title: 'ra-ui-materialui/input/AutocompleteInput' };
 
@@ -594,6 +596,48 @@ const CreateItemLabelInput = () => {
 export const CreateItemLabel = () => (
     <Wrapper>
         <CreateItemLabelInput />
+    </Wrapper>
+);
+
+const CreateItemLabelRenderedInput = () => {
+    const [choices, setChoices] = useState(choicesForCreationSupport);
+    return (
+        <AutocompleteInput
+            source="author"
+            choices={choices}
+            createLabel={
+                <Typography data-testid="new-choice-hint">
+                    Start typing to create a new <strong>author</strong>
+                </Typography>
+            }
+            createItemLabel={item => (
+                <Typography component="div">
+                    Create <Chip label={item} data-testid="new-choice-chip" />
+                </Typography>
+            )}
+            onCreate={async filter => {
+                const newAuthor = {
+                    id: choices.length + 1,
+                    name: filter,
+                };
+                setChoices(authors => [...authors, newAuthor]);
+                // Wait until next tick to give some time for React to update the state
+                await new Promise(resolve => setTimeout(resolve));
+                return newAuthor;
+            }}
+            TextFieldProps={{
+                placeholder: 'Start typing to create a new item',
+            }}
+            // Disable clearOnBlur because opening the prompt blurs the input
+            // and creates a flicker
+            clearOnBlur={false}
+        />
+    );
+};
+
+export const CreateItemLabelRendered = ({ delay = 0 }: { delay?: number }) => (
+    <Wrapper dataProvider={delayedDataProvider(dataProviderDefault, delay)}>
+        <CreateItemLabelRenderedInput />
     </Wrapper>
 );
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -447,6 +447,14 @@ If you provided a React element for the optionText prop, you must also provide t
             emptyValue,
         ]
     );
+    const getOptionLabelString = useCallback(
+        (option: any, isListItem: boolean = false) => {
+            const optionLabel = getOptionLabel(option, isListItem);
+            // Can be a ReactNode when it's the create option.
+            return typeof optionLabel === 'string' ? optionLabel : '';
+        },
+        [getOptionLabel]
+    );
 
     const finalOnBlur = useCallback(
         (event): void => {
@@ -493,10 +501,13 @@ If you provided a React element for the optionText prop, you must also provide t
             event?.type === 'change' ||
             !doesQueryMatchSelection(newInputValue)
         ) {
-            const createOptionLabel = translate(createItemLabel, {
-                item: filterValue,
-                _: createItemLabel,
-            });
+            const createOptionLabel =
+                typeof createItemLabel === 'string'
+                    ? translate(createItemLabel, {
+                          item: filterValue,
+                          _: createItemLabel,
+                      })
+                    : undefined;
             const isCreate = newInputValue === createOptionLabel;
             const valueToSet = isCreate ? filterValue : newInputValue;
             setFilterValue(valueToSet);
@@ -722,7 +733,8 @@ If you provided a React element for the optionText prop, you must also provide t
                         ? suggestions
                         : []
                 }
-                getOptionLabel={getOptionLabel}
+                getOptionKey={(option: any) => option?.id}
+                getOptionLabel={getOptionLabelString}
                 inputValue={filterValue}
                 loading={
                     isPending &&

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -18,6 +18,7 @@ import {
     InsideReferenceArrayInput,
     InsideReferenceArrayInputDefaultValue,
     CreateLabel,
+    CreateLabelRendered,
 } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
@@ -627,6 +628,19 @@ describe('<SelectArrayInput />', () => {
         fireEvent.click(await screen.findByText('Create a new role'));
         // Expect a dialog to have opened
         await screen.findByLabelText('Role name');
+    });
+
+    it('should support using a custom rendered createLabel', async () => {
+        render(<CreateLabelRendered />);
+        const input = (await screen.findByLabelText(
+            'Roles'
+        )) as HTMLInputElement;
+        fireEvent.mouseDown(input);
+        // Expect the custom create label to be displayed
+        const newRoleLabel = await screen.findByTestId('new-role-label');
+        expect(newRoleLabel.textContent).toBe('Create a new role');
+        fireEvent.click(newRoleLabel);
+        await screen.findByText('Role name');
     });
 
     it('should receive an event object on change', async () => {

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -9,6 +9,7 @@ import {
     IconButton,
     Stack,
     TextField,
+    Typography,
 } from '@mui/material';
 import fakeRestProvider from 'ra-data-fakerest';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
@@ -367,6 +368,22 @@ export const CreateLabel = () => (
             defaultValue={['u001', 'u003']}
             create={<CreateRole />}
             createLabel="Create a new role"
+        />
+    </Wrapper>
+);
+
+export const CreateLabelRendered = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={choices}
+            defaultValue={['u001', 'u003']}
+            create={<CreateRole />}
+            createLabel={
+                <Typography data-testid="new-role-label">
+                    Create a new <strong>role</strong>
+                </Typography>
+            }
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.spec.tsx
@@ -20,6 +20,7 @@ import {
     TranslateChoice,
     FetchChoices,
     CreateLabel,
+    CreateLabelRendered,
 } from './SelectInput.stories';
 
 describe('<SelectInput />', () => {
@@ -729,6 +730,20 @@ describe('<SelectInput />', () => {
                 expect(promptSpy).toHaveBeenCalled();
             });
             promptSpy.mockRestore();
+        });
+
+        it('should support using a custom rendered createLabel', async () => {
+            render(<CreateLabelRendered />);
+            const input = (await screen.findByLabelText(
+                'Category'
+            )) as HTMLInputElement;
+            fireEvent.mouseDown(input);
+            // Expect the custom create label to be displayed
+            const newCategoryLabel =
+                await screen.findByTestId('new-category-label');
+            expect(newCategoryLabel.textContent).toBe('Create a new category');
+            fireEvent.click(newCategoryLabel);
+            await screen.findByText('New category name');
         });
 
         it('should support using a custom createLabel with optionText being a string', async () => {

--- a/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.stories.tsx
@@ -7,6 +7,7 @@ import {
     DialogTitle,
     IconButton,
     TextField,
+    Typography,
 } from '@mui/material';
 import {
     CreateBase,
@@ -409,6 +410,21 @@ CreateLabel.argTypes = {
         control: { type: 'inline-radio' },
     },
 };
+
+export const CreateLabelRendered = () => (
+    <Wrapper>
+        <SelectInput
+            createLabel={
+                <Typography data-testid="new-category-label">
+                    Create a new <strong>category</strong>
+                </Typography>
+            }
+            create={<CreateCategory />}
+            source="category"
+            choices={categories}
+        />
+    </Wrapper>
+);
 
 const i18nProvider = polyglotI18nProvider(() => englishMessages);
 

--- a/packages/ra-ui-materialui/src/input/common.tsx
+++ b/packages/ra-ui-materialui/src/input/common.tsx
@@ -1,5 +1,6 @@
 import * as React from 'react';
 import { useWatch } from 'react-hook-form';
+import { DataProvider } from 'ra-core';
 
 export const FormInspector = ({ name = 'title' }) => {
     const value = useWatch({ name });
@@ -12,3 +13,21 @@ export const FormInspector = ({ name = 'title' }) => {
         </div>
     );
 };
+
+export const delayedDataProvider = (
+    dataProvider: DataProvider,
+    delay = process.env.NODE_ENV === 'test' ? 100 : 300
+) =>
+    new Proxy(dataProvider, {
+        get: (target, name) => (resource, params) => {
+            if (typeof name === 'symbol' || name === 'then') {
+                return;
+            }
+            return new Promise(resolve =>
+                setTimeout(
+                    () => resolve(dataProvider[name](resource, params)),
+                    delay
+                )
+            );
+        },
+    });

--- a/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
+++ b/packages/ra-ui-materialui/src/input/useSupportCreateSuggestion.tsx
@@ -16,8 +16,8 @@ import set from 'lodash/set';
  *
  * @param options The hook option
  * @param {ReactElement} options.create A react element which will be rendered when users choose to create a new choice. This component must call the `useCreateSuggestionContext` hook which provides `onCancel`, `onCreate` and `filter`. See the examples.
- * @param {String} options.createLabel Optional. The label for the choice item allowing users to create a new choice. Can be a translation key. Defaults to `ra.action.create`.
- * @param {String} options.createItemLabel Optional. The label for the choice item allowing users to create a new choice when they already entered a filter. Can be a translation key. The translation will receive an `item` parameter. Providing this option will turn the create label when there is no filter to be a hint (i.e. a disabled item).
+ * @param {React.ReactNode|string} options.createLabel Optional. The label for the choice item allowing users to create a new choice. Can be a translation key. Defaults to `ra.action.create`.
+ * @param {React.ReactNode|string} options.createItemLabel Optional. The label for the choice item allowing users to create a new choice when they already entered a filter. Can be a translation key. The function and ttranslation will receive an `item` parameter. Providing this option will turn the create label when there is no filter to be a hint (i.e. a disabled item).
  * @param {any} options.createValue Optional. The value for the choice item allowing users to create a new choice. Defaults to `@@ra-create`.
  * @param {any} options.createHintValue Optional. The value for the (disabled) item hinting users on how to create a new choice. Defaults to `@@ra-create-hint`.
  * @param {String} options.filter Optional. The filter users may have already entered. Useful for autocomplete inputs for example.
@@ -64,11 +64,15 @@ export const useSupportCreateSuggestion = (
                 },
                 typeof optionText === 'string' ? optionText : 'name',
                 filter && createItemLabel
-                    ? translate(createItemLabel, {
-                          item: filter,
-                          _: createItemLabel,
-                      })
-                    : translate(createLabel, { _: createLabel })
+                    ? typeof createItemLabel === 'string'
+                        ? translate(createItemLabel, {
+                              item: filter,
+                              _: createItemLabel,
+                          })
+                        : createItemLabel(filter)
+                    : typeof createLabel === 'string'
+                      ? translate(createLabel, { _: createLabel })
+                      : createLabel
             );
         },
         handleChange: async (eventOrValue: MouseEvent | any) => {
@@ -120,8 +124,8 @@ export interface SupportCreateSuggestionOptions {
     create?: ReactElement;
     createValue?: string;
     createHintValue?: string;
-    createLabel?: string;
-    createItemLabel?: string;
+    createLabel?: React.ReactNode;
+    createItemLabel?: string | ((filter: string) => React.ReactNode);
     filter?: string;
     handleChange: (value: any) => void;
     onCreate?: OnCreateHandler;
@@ -149,6 +153,7 @@ interface CreateSuggestionContextValue {
     onCreate: (choice: any) => void;
     onCancel: () => void;
 }
+
 export const useCreateSuggestionContext = () => {
     const context = useContext(CreateSuggestionContext);
     if (!context) {


### PR DESCRIPTION
## Problem

Customizing the label for creating a new choice in AutocompleteInput with more than just text is not possible without rewriting the whole component.

## Solution

Accept a `ReactNode` in `createLabel` prop, and a function returning a `ReactNode` in `createItemLabel` prop.

## How To Test

- Story: [AutocompleteInput](https://react-admin-storybook-8z2fzdbt1-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-autocompleteinput--create-item-label-rendered)
- Story: [AutocompleteArrayInput](https://react-admin-storybook-8z2fzdbt1-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-autocompletearrayinput--create-item-label-rendered)
- Story: [SelectInput](https://react-admin-storybook-8z2fzdbt1-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-selectinput--create-label-rendered)
- Story: [SelectArrayInput](https://react-admin-storybook-8z2fzdbt1-marmelab.vercel.app/?path=/story/ra-ui-materialui-input-selectarrayinput--create-label-rendered)

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
