### PR TITLE
Fix error when authProvider check methods are not async

### DIFF
--- a/packages/ra-core/src/auth/useAuthState.ts
+++ b/packages/ra-core/src/auth/useAuthState.ts
@@ -62,22 +62,21 @@ const useAuthState = <ErrorType = Error>(
 
     const queryResult = useQuery<boolean, any>({
         queryKey: ['auth', 'checkAuth', params],
-        queryFn: ({ signal }) => {
+        queryFn: async ({ signal }) => {
             // The authProvider is optional in react-admin
             if (!authProvider) {
                 return true;
             }
-            return authProvider
-                .checkAuth({ ...params, signal })
-                .then(() => true)
-                .catch(error => {
-                    // This is necessary because react-query requires the error to be defined
-                    if (error != null) {
-                        throw error;
-                    }
-
-                    throw new Error();
-                });
+            try {
+                await authProvider.checkAuth({ ...params, signal });
+                return true;
+            } catch (error) {
+                // This is necessary because react-query requires the error to be defined
+                if (error != null) {
+                    throw error;
+                }
+                throw new Error();
+            }
         },
         retry: false,
         ...options,


### PR DESCRIPTION
## Problem

When a developer forgets to return a Promise in `authProvider.checkAuth()` or `authProvider.checkError()`, they see a cryptic error message:

> Cannot read properties of undefined (reading 'then')

## Solution

Although the doc (and typescript) specifies that these methods must be async, react-admin can be more permissive and not throw any error in this case, by using async methods instead of promises. 

## How To Test

Update the authProvider in the simple example to use sync methods:

```js
    checkError: ({ status }) => {
        if (status === 401 || status === 403) {
            throw new Error();
        }
    },
    checkAuth: () => {
        if (localStorage.getItem('not_authenticated')) {
            throw new Error();
        }
    },
```

The simple example should still work. 

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~
- ~~[ ] The PR includes one or several **stories** (if not possible, describe why)~~
- [x] The **documentation** is up to date

No tests or stories because this is a corner case. 
