### PR TITLE
[chore] Fix CRM demo cannot load MSW when deployed on a sub URL

### DIFF
--- a/examples/crm/src/index.tsx
+++ b/examples/crm/src/index.tsx
@@ -7,13 +7,19 @@ import { worker } from './providers/fakerest/fakeServer';
 const container = document.getElementById('root');
 const root = createRoot(container!);
 
-worker.start({ onUnhandledRequest: 'bypass', quiet: true }).then(() => {
-    root.render(
-        <React.StrictMode>
-            <App />
-        </React.StrictMode>
-    );
-});
+worker
+    .start({
+        onUnhandledRequest: 'bypass',
+        quiet: true,
+        serviceWorker: { url: './mockServiceWorker.js' },
+    })
+    .then(() => {
+        root.render(
+            <React.StrictMode>
+                <App />
+            </React.StrictMode>
+        );
+    });
 
 // If you want to start measuring performance in your app, pass a function
 // to log results (for example: reportWebVitals(console.log))


### PR DESCRIPTION
## Problem

When deployed on https://marmelab.com/react-admin-crm/, the service worker URL is wrong

## Solution

Fix the service worker URL so that it works both locally and when deployed on https://marmelab.com/react-admin-crm/
