### PR TITLE
Improve offline detection in Edit, Show, ReferenceField and ReferenceOneField

### DIFF
--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -422,6 +422,8 @@ describe('EditBase', () => {
             screen.queryByText('You are offline, cannot load data')
         ).toBeNull();
         rerender(<Offline isOnline={false} />);
+        // Ensure the data is still displayed when going offline after it was loaded
         await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('Hello');
     });
 });

--- a/packages/ra-core/src/controller/edit/EditBase.stories.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.stories.tsx
@@ -198,7 +198,11 @@ export const Offline = ({
                 {...defaultProps}
                 {...props}
                 mutationMode="pessimistic"
-                offline={<p>You are offline, cannot load data</p>}
+                offline={
+                    <p style={{ color: 'orange' }}>
+                        You are offline, cannot load data
+                    </p>
+                }
             >
                 <OfflineChild />
             </EditBase>

--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -61,7 +61,7 @@ export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
         );
     }
 
-    const { isPaused, record } = controllerProps;
+    const { isPaused, isPending } = controllerProps;
 
     const shouldRenderLoading =
         isAuthPending &&
@@ -70,7 +70,7 @@ export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
         loading !== undefined;
 
     const shouldRenderOffline =
-        isPaused && !record && offline !== false && offline !== undefined;
+        isPaused && isPending && offline !== false && offline !== undefined;
 
     return (
         // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -175,5 +175,9 @@ describe('<ReferenceFieldBase />', () => {
         await screen.findByText('You are offline, cannot load data');
         fireEvent.click(await screen.findByText('Simulate online'));
         await screen.findByText('Leo');
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        // Ensure the data is still displayed when going offline after it was loaded
+        await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('Leo');
     });
 });

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.stories.tsx
@@ -10,6 +10,7 @@ import { useFieldValue } from '../../util/useFieldValue';
 import { useReferenceFieldContext } from './ReferenceFieldContext';
 import { DataProvider } from '../../types';
 import { useIsOffline } from '../../core/useIsOffline';
+import { IsOffline } from '../..';
 
 export default {
     title: 'ra-core/controller/field/ReferenceFieldBase',
@@ -422,13 +423,19 @@ export const Offline = () => {
                                         source="author"
                                         reference="authors"
                                         offline={
-                                            <p>
+                                            <p style={{ color: 'orange' }}>
                                                 You are offline, cannot load
                                                 data
                                             </p>
                                         }
                                     >
                                         <MyReferenceField>
+                                            <IsOffline>
+                                                <p style={{ color: 'orange' }}>
+                                                    You are offline, the data
+                                                    may be outdated
+                                                </p>
+                                            </IsOffline>
                                             <TextField source="first_name" />
                                         </MyReferenceField>
                                     </ReferenceFieldBase>

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.tsx
@@ -72,10 +72,7 @@ export const ReferenceFieldBase = <
         loading !== false &&
         loading !== undefined;
     const shouldRenderOffline =
-        isPaused &&
-        !referenceRecord &&
-        offline !== false &&
-        offline !== undefined;
+        isPaused && isPending && offline !== false && offline !== undefined;
     const shouldRenderError =
         !!controllerError && error !== false && error !== undefined;
     const shouldRenderEmpty =

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
@@ -67,8 +67,12 @@ describe('ReferenceOneFieldBase', () => {
         render(<Offline />);
         fireEvent.click(await screen.findByText('Simulate offline'));
         fireEvent.click(await screen.findByText('Toggle Child'));
-        await screen.findByText('Offline');
+        await screen.findByText('You are offline, cannot load data');
         fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('9780393966473');
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        // Ensure the data is still displayed when going offline after it was loaded
+        await screen.findByText('You are offline, the data may be outdated');
         await screen.findByText('9780393966473');
     });
 });

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.stories.tsx
@@ -2,6 +2,7 @@ import * as React from 'react';
 
 import {
     CoreAdminContext,
+    IsOffline,
     RecordContextProvider,
     ReferenceOneFieldBase,
     ResourceContextProvider,
@@ -111,8 +112,17 @@ export const Offline = () => {
                     <ReferenceOneFieldBase
                         reference="book_details"
                         target="book_id"
-                        offline={<span>Offline</span>}
+                        offline={
+                            <span style={{ color: 'orange' }}>
+                                You are offline, cannot load data
+                            </span>
+                        }
                     >
+                        <IsOffline>
+                            <p style={{ color: 'orange' }}>
+                                You are offline, the data may be outdated
+                            </p>
+                        </IsOffline>
                         <BookDetails />
                     </ReferenceOneFieldBase>
                 </RenderChildOnDemand>

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.tsx
@@ -89,10 +89,7 @@ export const ReferenceOneFieldBase = <
     const shouldRenderLoading =
         !isPaused && isPending && loading !== false && loading !== undefined;
     const shouldRenderOffline =
-        isPaused &&
-        !referenceRecord &&
-        offline !== false &&
-        offline !== undefined;
+        isPaused && isPending && offline !== false && offline !== undefined;
     const shouldRenderError =
         !!controllerError && error !== false && error !== undefined;
     const shouldRenderEmpty =

--- a/packages/ra-core/src/controller/show/ShowBase.spec.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.spec.tsx
@@ -130,5 +130,8 @@ describe('ShowBase', () => {
         ).toBeNull();
         rerender(<Offline isOnline={false} />);
         await screen.findByText('You are offline, the data may be outdated');
+        // Ensure the data is still displayed when going offline after it was loaded
+        await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('Hello');
     });
 });

--- a/packages/ra-core/src/controller/show/ShowBase.stories.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.stories.tsx
@@ -180,7 +180,11 @@ export const Offline = ({
             <ShowBase
                 {...defaultProps}
                 {...props}
-                offline={<p>You are offline, cannot load data</p>}
+                offline={
+                    <p style={{ color: 'orange' }}>
+                        You are offline, cannot load data
+                    </p>
+                }
             >
                 <OfflineChild />
             </ShowBase>

--- a/packages/ra-core/src/controller/show/ShowBase.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.tsx
@@ -60,7 +60,7 @@ export const ShowBase = <RecordType extends RaRecord = any>({
         );
     }
 
-    const { isPaused, record } = controllerProps;
+    const { isPaused, isPending } = controllerProps;
 
     const shouldRenderLoading =
         isAuthPending &&
@@ -69,7 +69,7 @@ export const ShowBase = <RecordType extends RaRecord = any>({
         loading !== undefined;
 
     const shouldRenderOffline =
-        isPaused && !record && offline !== false && offline !== undefined;
+        isPaused && isPending && offline !== false && offline !== undefined;
 
     return (
         // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -45,7 +45,7 @@ export const EditView = (props: EditViewProps) => {
     const finalActions =
         typeof actions === 'undefined' && hasShow ? defaultActions : actions;
 
-    if (!record && offline !== false && isPaused) {
+    if (isPaused && isPending && offline !== undefined && offline !== false) {
         return (
             <Root className={clsx('edit-page', className)} {...rest}>
                 <div className={clsx(EditClasses.main, EditClasses.noActions)}>

--- a/packages/ra-ui-materialui/src/detail/ShowView.tsx
+++ b/packages/ra-ui-materialui/src/detail/ShowView.tsx
@@ -36,13 +36,13 @@ export const ShowView = (props: ShowViewProps) => {
     } = props;
 
     const showContext = useShowContext();
-    const { resource, defaultTitle, isPaused, record } = showContext;
+    const { resource, defaultTitle, isPaused, isPending, record } = showContext;
     const { hasEdit } = useResourceDefinition();
 
     const finalActions =
         typeof actions === 'undefined' && hasEdit ? defaultActions : actions;
 
-    if (!record && offline !== false && isPaused) {
+    if (isPaused && isPending && offline !== undefined && offline !== false) {
         return (
             <Root className={clsx('show-page', className)} {...rest}>
                 <div className={clsx(ShowClasses.main, ShowClasses.noActions)}>

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -772,5 +772,9 @@ describe('<ReferenceField />', () => {
         await screen.findByText('No connectivity. Could not fetch data.');
         fireEvent.click(await screen.findByText('Simulate online'));
         await screen.findByText('9780393966473');
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        // Ensure the data is still displayed when going offline after it was loaded
+        await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('9780393966473');
     });
 });

--- a/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.stories.tsx
@@ -13,12 +13,13 @@ import {
     TestMemoryRouter,
     AuthProvider,
     useIsOffline,
+    IsOffline,
 } from 'ra-core';
 
 import fakeRestDataProvider from 'ra-data-fakerest';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
-import { createTheme, Stack, ThemeOptions } from '@mui/material';
+import { createTheme, Stack, ThemeOptions, Typography } from '@mui/material';
 import { onlineManager, QueryClient } from '@tanstack/react-query';
 import { deepmerge } from '@mui/utils';
 
@@ -967,7 +968,7 @@ export const WithRenderProp = () => (
                 if (error) {
                     return <p style={{ color: 'red' }}>{error.message}</p>;
                 }
-                return referenceRecord.ISBN;
+                return referenceRecord?.ISBN;
             }}
         ></ReferenceField>
     </Wrapper>
@@ -978,7 +979,16 @@ export const Offline = () => (
         <I18nContextProvider value={i18nProvider}>
             <div>
                 <RenderChildOnDemand>
-                    <ReferenceField source="detail_id" reference="book_details">
+                    <ReferenceField
+                        source="detail_id"
+                        reference="book_details"
+                        link={false}
+                    >
+                        <IsOffline>
+                            <Typography color="warning">
+                                You are offline, the data may be outdated
+                            </Typography>
+                        </IsOffline>
                         <TextField source="ISBN" />
                     </ReferenceField>
                 </RenderChildOnDemand>


### PR DESCRIPTION
## Problem

The current detection mechanism relies on `isPaused` and the record presence which is wrong.

## Solution

Rely on both `isPaused` and `isPending` (which means no data has been **fetched** yet).

**NOTE**: I didn't update `ReferenceManyFieldBase` yet as I'll open a PR for it and `ReferenceManyField` that has no offline support yet

## How To Test

- Tests have been improved
- Stories have been improved

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
