### PR TITLE
Add offline support to `<ReferenceArrayFieldBase>` and `<ReferenceArrayField>`

### DIFF
--- a/docs/Edit.md
+++ b/docs/Edit.md
@@ -542,7 +542,7 @@ The default `onError` function is:
 
 ## `offline`
 
-By default, `<EditBase>` renders nothing when there is no connectivity and the record hasn't been cached yet. You can provide your own component via the `offline` prop:
+By default, `<Edit>` renders the `<Offline>` component when there is no connectivity and the record hasn't been cached yet. You can provide your own component via the `offline` prop:
 
 ```jsx
 import { Edit } from 'react-admin';

--- a/docs/ReferenceArrayField.md
+++ b/docs/ReferenceArrayField.md
@@ -85,10 +85,11 @@ You can change how the list of related records is rendered by passing a custom c
 | -------------- | -------- | --------------------------------------------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------------------------------------ |
 | `source`       | Required | `string`                                                                          | -                                | Name of the property to display                                                                        |
 | `reference`    | Required | `string`                                                                          | -                                | The name of the resource for the referenced records, e.g. 'tags'                                       |
-| `children`     | Optional&nbsp;* | `Element`                                                                         | `<SingleFieldList>`              | One or several elements that render a list of records based on a `ListContext`                         |
+| `children`     | Optional&nbsp;* | `ReactNode`                                                                         | `<SingleFieldList>`              | One or several elements that render a list of records based on a `ListContext`                         |
 | `render`     | Optional&nbsp;* | `(listContext) => Element`                                                                         | `<SingleFieldList>`              | A function that takes a list context and render a list of records                         |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records (the filtering is done client-side)                   |
-| `pagination`   | Optional | `Element`                                                                         | -                                | Pagination element to display pagination controls. empty by default (no pagination)                    |
+| `offline`      | Optional | `ReactNode`                                                              | `<Offline variant="inline" />` | The component to render when there is no connectivity and the record isn't in the cache |
+| `pagination`   | Optional | `ReactNode`                                                                         | -                                | Pagination element to display pagination controls. empty by default (no pagination)                    |
 | `perPage`      | Optional | `number`                                                                          | 1000                             | Maximum number of results to display                                                                   |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                                                           |
 | `sort`         | Optional | `{ field, order }`                                                                | `{ field: 'id', order: 'DESC' }` | Sort order to use when displaying the related records (the sort is done client-side)                   |
@@ -233,6 +234,47 @@ React-admin uses [the i18n system](./Translation.md) to translate the label, so 
 
 ```jsx
 <ReferenceArrayField label="resource.posts.fields.tags" source="tag_ids" reference="tags" />
+```
+
+## `offline`
+
+By default, `<ReferenceArrayField>` renders the `<Offline variant="inline">` when there is no connectivity and the records haven't been cached yet. You can provide your own component via the `offline` prop:
+
+```jsx
+import { ReferenceArrayField, Show } from 'react-admin';
+import { Alert } from '@mui/material';
+
+export const PostShow = () => (
+    <Show>
+        <ReferenceArrayField
+            source="tag_ids"
+            reference="tags"
+            offline={<Alert severity="warning">No network. Could not load the tags.</Alert>}
+        >
+            ...
+        </ReferenceArrayField>
+    </Show>
+);
+```
+
+**Tip**: If the records are in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
+
+```jsx
+import { IsOffline, ReferenceArrayField, Show } from 'react-admin';
+import { Alert } from '@mui/material';
+
+export const PostShow = () => (
+    <Show>
+        <ReferenceArrayField source="tag_ids" reference="tags">
+            <IsOffline>
+                <Alert severity="warning">
+                    You are offline, tags may be outdated
+                </Alert>
+            </IsOffline>
+            ...
+        </ReferenceArrayField>
+    </Show>
+);
 ```
 
 ## `pagination`

--- a/docs/ReferenceArrayFieldBase.md
+++ b/docs/ReferenceArrayFieldBase.md
@@ -92,6 +92,7 @@ You can change how the list of related records is rendered by passing a custom c
 | `children`     | Optional\* | `Element`                                                                         |               | One or several elements that render a list of records based on a `ListContext`                         |
 | `render`     | Optional\* | `(ListContext) => Element`                                                                         |               | A function that takes a list context and renders a list of records                        |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records (the filtering is done client-side)                   |
+| `offline`      | Optional | `ReactNode`                                                              |              | The component to render when there is no connectivity and the record isn't in the cache |
 | `perPage`      | Optional | `number`                                                                          | 1000                             | Maximum number of results to display                                                                   |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                                                           |
 | `sort`         | Optional | `{ field, order }`                                                                | `{ field: 'id', order: 'DESC' }` | Sort order to use when displaying the related records (the sort is done client-side)                   |
@@ -174,6 +175,49 @@ For instance, to render only tags that are 'published', you can use the followin
 />
 ```
 {% endraw %}
+
+## `offline`
+
+By default, `<ReferenceArrayFieldBase>` renders nothing when there is no connectivity and the records haven't been cached yet. You can provide your own component via the `offline` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            offline={<p>No network. Could not load the tags.</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+**Tip**: If the records are in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
+
+```jsx
+import { IsOffline, ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            offline={<p>No network. Could not load the tags.</p>}
+        >
+            <IsOffline>
+                <p>
+                    You are offline, tags may be outdated
+                </p>
+            </IsOffline>
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
 
 ## `perPage`
 

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.spec.tsx
@@ -1,9 +1,10 @@
 import * as React from 'react';
-import { render, screen, waitFor } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
     Basic,
     Errored,
     Loading,
+    Offline,
     WithRenderProp,
 } from './ReferenceArrayFieldBase.stories';
 
@@ -82,5 +83,19 @@ describe('ReferenceArrayFieldBase', () => {
             expect(screen.queryByText('Ronnie Wood')).not.toBeNull();
             expect(screen.queryByText('Charlie Watts')).not.toBeNull();
         });
+    });
+
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        await screen.findByText('The Beatles');
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('You are offline, cannot load data');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('John Lennon');
+        // Ensure the data is still displayed when going offline after it was loaded
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('John Lennon');
     });
 });

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.tsx
@@ -108,12 +108,20 @@ export const ReferenceArrayFieldBase = <
             "<ReferenceArrayFieldBase> requires either a 'render' prop or 'children' prop"
         );
     }
-    const { error: controllerError, isPending, isPaused } = controllerProps;
+    const {
+        error: controllerError,
+        isPending,
+        isPaused,
+        isPlaceholderData,
+    } = controllerProps;
 
     const shouldRenderLoading =
         isPending && !isPaused && loading !== undefined && loading !== false;
     const shouldRenderOffline =
-        isPending && isPaused && offline !== undefined && offline !== false;
+        isPaused &&
+        (isPending || isPlaceholderData) &&
+        offline !== undefined &&
+        offline !== false;
     const shouldRenderError =
         !isPending &&
         !isPaused &&

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.tsx
@@ -78,6 +78,7 @@ export const ReferenceArrayFieldBase = <
         loading,
         empty,
         filter,
+        offline,
         page = 1,
         perPage,
         reference,
@@ -107,25 +108,19 @@ export const ReferenceArrayFieldBase = <
             "<ReferenceArrayFieldBase> requires either a 'render' prop or 'children' prop"
         );
     }
+    const { error: controllerError, isPending, isPaused } = controllerProps;
 
-    if (controllerProps.isPending && loading) {
-        return (
-            <ResourceContextProvider value={reference}>
-                {loading}
-            </ResourceContextProvider>
-        );
-    }
-    if (controllerProps.error && error) {
-        return (
-            <ResourceContextProvider value={reference}>
-                <ListContextProvider value={controllerProps}>
-                    {error}
-                </ListContextProvider>
-            </ResourceContextProvider>
-        );
-    }
-    if (
-        // there is an empty page component
+    const shouldRenderLoading =
+        isPending && !isPaused && loading !== undefined && loading !== false;
+    const shouldRenderOffline =
+        isPending && isPaused && offline !== undefined && offline !== false;
+    const shouldRenderError =
+        !isPending &&
+        !isPaused &&
+        controllerError &&
+        error !== undefined &&
+        error !== false;
+    const shouldRenderEmpty = // there is an empty page component
         empty &&
         // there is no error
         !controllerProps.error &&
@@ -141,19 +136,22 @@ export const ReferenceArrayFieldBase = <
                 // @ts-ignore FIXME total may be undefined when using partial pagination but the ListControllerResult type is wrong about it
                 controllerProps.data.length === 0)) &&
         // the user didn't set any filters
-        !Object.keys(controllerProps.filterValues).length
-    ) {
-        return (
-            <ResourceContextProvider value={reference}>
-                {empty}
-            </ResourceContextProvider>
-        );
-    }
+        !Object.keys(controllerProps.filterValues).length;
 
     return (
         <ResourceContextProvider value={reference}>
             <ListContextProvider value={controllerProps}>
-                {render ? render(controllerProps) : children}
+                {shouldRenderLoading
+                    ? loading
+                    : shouldRenderOffline
+                      ? offline
+                      : shouldRenderError
+                        ? error
+                        : shouldRenderEmpty
+                          ? empty
+                          : render
+                            ? render(controllerProps)
+                            : children}
             </ListContextProvider>
         </ResourceContextProvider>
     );
@@ -169,6 +167,7 @@ export interface ReferenceArrayFieldBaseProps<
     loading?: ReactNode;
     empty?: ReactNode;
     filter?: FilterPayload;
+    offline?: ReactNode;
     page?: number;
     perPage?: number;
     reference: string;

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.stories.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.stories.tsx
@@ -95,5 +95,5 @@ export const Basic = ({ children = defaultRenderProp }) => (
 );
 
 export default {
-    title: 'ra-core/controller/useReferenceArrayFieldController',
+    title: 'ra-core/controller/field/useReferenceArrayFieldController',
 };

--- a/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
+++ b/packages/ra-core/src/controller/field/useReferenceArrayFieldController.ts
@@ -76,32 +76,40 @@ export const useReferenceArrayFieldController = <
     const { meta, ...otherQueryOptions } = queryOptions;
     const ids = Array.isArray(value) ? value : emptyArray;
 
-    const { data, error, isLoading, isFetching, isPending, refetch } =
-        useGetManyAggregate<ReferenceRecordType, ErrorType>(
-            reference,
-            { ids, meta },
-            {
-                onError: error =>
-                    notify(
-                        typeof error === 'string'
-                            ? error
-                            : (error as Error)?.message ||
-                                  'ra.notification.http_error',
-                        {
-                            type: 'error',
-                            messageArgs: {
-                                _:
-                                    typeof error === 'string'
-                                        ? error
-                                        : (error as Error)?.message
-                                          ? (error as Error).message
-                                          : undefined,
-                            },
-                        }
-                    ),
-                ...otherQueryOptions,
-            }
-        );
+    const {
+        data,
+        error,
+        isLoading,
+        isFetching,
+        isPaused,
+        isPending,
+        isPlaceholderData,
+        refetch,
+    } = useGetManyAggregate<ReferenceRecordType, ErrorType>(
+        reference,
+        { ids, meta },
+        {
+            onError: error =>
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : (error as Error)?.message ||
+                              'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
+                                      : undefined,
+                        },
+                    }
+                ),
+            ...otherQueryOptions,
+        }
+    );
 
     const listProps = useList<ReferenceRecordType, ErrorType>({
         data,
@@ -109,7 +117,9 @@ export const useReferenceArrayFieldController = <
         filter,
         isFetching,
         isLoading,
+        isPaused,
         isPending,
+        isPlaceholderData,
         page,
         perPage,
         sort,

--- a/packages/ra-core/src/controller/field/useReferenceManyFieldController.stories.tsx
+++ b/packages/ra-core/src/controller/field/useReferenceManyFieldController.stories.tsx
@@ -110,6 +110,6 @@ export const Basic = ({
 );
 
 export default {
-    title: 'ra-core/controller/useReferenceManyFieldController',
+    title: 'ra-core/controller/field/useReferenceManyFieldController',
     excludeStories: ['defaultDataProvider'],
 };

--- a/packages/ra-core/src/controller/list/useList.ts
+++ b/packages/ra-core/src/controller/list/useList.ts
@@ -61,28 +61,15 @@ export const useList = <RecordType extends RaRecord = any, ErrorType = Error>(
         filter = defaultFilter,
         isFetching = false,
         isLoading = false,
+        isPaused = false,
         isPending = false,
+        isPlaceholderData = false,
         page: initialPage = 1,
         perPage: initialPerPage = 1000,
         sort: initialSort,
         filterCallback = (record: RecordType) => Boolean(record),
     } = props;
     const resource = useResourceContext(props);
-
-    const [fetchingState, setFetchingState] = useState<boolean>(isFetching) as [
-        boolean,
-        (isFetching: boolean) => void,
-    ];
-
-    const [loadingState, setLoadingState] = useState<boolean>(isLoading) as [
-        boolean,
-        (isLoading: boolean) => void,
-    ];
-
-    const [pendingState, setPendingState] = useState<boolean>(isPending) as [
-        boolean,
-        (isPending: boolean) => void,
-    ];
 
     const [finalItems, setFinalItems] = useState<{
         data?: RecordType[];
@@ -250,24 +237,6 @@ export const useList = <RecordType extends RaRecord = any, ErrorType = Error>(
         ]
     );
 
-    useEffect(() => {
-        if (isFetching !== fetchingState) {
-            setFetchingState(isFetching);
-        }
-    }, [isFetching, fetchingState, setFetchingState]);
-
-    useEffect(() => {
-        if (isLoading !== loadingState) {
-            setLoadingState(isLoading);
-        }
-    }, [isLoading, loadingState, setLoadingState]);
-
-    useEffect(() => {
-        if (isPending !== pendingState) {
-            setPendingState(isPending);
-        }
-    }, [isPending, pendingState, setPendingState]);
-
     const onSelectAll = useCallback(() => {
         const allIds = data?.map(({ id }) => id) || [];
         selectionModifiers.select(allIds);
@@ -275,7 +244,7 @@ export const useList = <RecordType extends RaRecord = any, ErrorType = Error>(
 
     return {
         sort,
-        data: pendingState ? undefined : finalItems?.data ?? [],
+        data: isPending ? undefined : finalItems?.data ?? [],
         defaultTitle: '',
         error: error ?? null,
         displayedFilters,
@@ -286,9 +255,11 @@ export const useList = <RecordType extends RaRecord = any, ErrorType = Error>(
                 : page * perPage < finalItems.total,
         hasPreviousPage: page > 1,
         hideFilter,
-        isFetching: fetchingState,
-        isLoading: loadingState,
-        isPending: pendingState,
+        isFetching,
+        isLoading,
+        isPaused,
+        isPending,
+        isPlaceholderData,
         onSelect: selectionModifiers.select,
         onSelectAll,
         onToggleItem: selectionModifiers.toggle,
@@ -316,7 +287,9 @@ export interface UseListOptions<
     filter?: FilterPayload;
     isFetching?: boolean;
     isLoading?: boolean;
+    isPaused?: boolean;
     isPending?: boolean;
+    isPlaceholderData?: boolean;
     page?: number;
     perPage?: number;
     sort?: SortPayload;

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
@@ -27,6 +27,7 @@ import { SingleFieldList } from '../list';
 import { AdminContext } from '../AdminContext';
 import {
     DifferentIdTypes,
+    Offline,
     WithPagination,
     WithRenderProp,
 } from './ReferenceArrayField.stories';
@@ -401,5 +402,18 @@ describe('<ReferenceArrayField />', () => {
             fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
             await screen.findByText('8 items selected');
         });
+    });
+    it('should render the offline prop node when offline', async () => {
+        render(<Offline />);
+        await screen.findByText('The Beatles');
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        fireEvent.click(await screen.findByText('Toggle Child'));
+        await screen.findByText('No connectivity. Could not fetch data.');
+        fireEvent.click(await screen.findByText('Simulate online'));
+        await screen.findByText('John Lennon');
+        // Ensure the data is still displayed when going offline after it was loaded
+        fireEvent.click(await screen.findByText('Simulate offline'));
+        await screen.findByText('You are offline, the data may be outdated');
+        await screen.findByText('John Lennon');
     });
 });


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<ReferenceArrayFieldBase>`](https://react-admin-storybook-q8f806rod-marmelab.vercel.app/?path=/story/ra-core-controller-field-referencearrayfieldbase--offline)
- [`<ReferenceArrayField>`](https://react-admin-storybook-q8f806rod-marmelab.vercel.app/?path=/story/ra-ui-materialui-fields-referencearrayfield--offline) 
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).