### PR TITLE
Add offline support to `<ReferenceManyFieldBase>` and `<ReferenceManyField>`

### DIFF
--- a/docs/ReferenceManyField.md
+++ b/docs/ReferenceManyField.md
@@ -96,6 +96,7 @@ This example leverages [`<SingleFieldList>`](./SingleFieldList.md) to display an
 | `debounce`     | Optional | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
 | `empty`        | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records.                                |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records, passed to `getManyReference()`    |
+| `offline`      | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records because of lack of network connectivity. |
 | `pagination`   | Optional | `Element`                                                                         | -                                | Pagination element to display pagination controls. empty by default (no pagination) |
 | `perPage`      | Optional | `number`                                                                          | 25                               | Maximum number of referenced records to fetch                                       |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                       |
@@ -304,6 +305,49 @@ React-admin uses [the i18n system](./Translation.md) to translate the label, so 
     <DataTable.Col source="title" />
     <DataTable.Col source="published_at" field={DateField} />
   </DataTable>
+</ReferenceManyField>
+```
+
+## `offline`
+
+Use `offline` to customize the text displayed when there are no related records because of lack of network connectivity.
+
+```jsx
+<ReferenceManyField
+    reference="books"
+    target="author_id"
+    offline="Offline, could not load data"
+>
+    ...
+</ReferenceManyField>
+```
+
+`offline` also accepts a `ReactNode`.
+
+```jsx
+<ReferenceManyField
+    reference="books"
+    target="author_id"
+    empty={<Alert severity="warning">Offline, could not load data</Alert>}
+>
+    ...
+</ReferenceManyField>
+```
+
+**Tip**: If the records are in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
+
+```jsx
+<ReferenceManyField
+    reference="books"
+    target="author_id"
+    empty={<Alert severity="warning">Offline, could not load data</Alert>}
+>
+  <IsOffline>
+      <Alert severity="warning">
+          You are offline, the data may be outdated
+      </Alert>
+  </IsOffline>
+    ...
 </ReferenceManyField>
 ```
 

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldBase.tsx
@@ -113,14 +113,20 @@ export const ReferenceManyFieldBase = <
         hasPreviousPage,
         isPaused,
         isPending,
+        isPlaceholderData,
         total,
     } = controllerProps;
 
-    const showLoading =
+    const shouldRenderLoading =
         isPending && !isPaused && loading !== false && loading !== undefined;
-    const showOffline = isPaused && offline !== false && offline !== undefined;
-    const showError = controllerError && error !== false && error !== undefined;
-    const showEmpty =
+    const showOffline =
+        isPaused &&
+        (isPending || isPlaceholderData) &&
+        offline !== false &&
+        offline !== undefined;
+    const shouldRenderError =
+        controllerError && error !== false && error !== undefined;
+    const shouldRenderEmpty =
         empty !== false &&
         empty !== undefined &&
         // there is no error
@@ -142,13 +148,13 @@ export const ReferenceManyFieldBase = <
     return (
         <ResourceContextProvider value={reference}>
             <ListContextProvider value={controllerProps}>
-                {showLoading
+                {shouldRenderLoading
                     ? loading
                     : showOffline
                       ? offline
-                      : showError
+                      : shouldRenderError
                         ? error
-                        : showEmpty
+                        : shouldRenderEmpty
                           ? empty
                           : render
                             ? render(controllerProps)

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.tsx
@@ -8,6 +8,7 @@ import {
 
 import { Typography } from '@mui/material';
 import type { FieldProps } from './types';
+import { Offline } from '../Offline';
 
 /**
  * Render related records to the current one.
@@ -62,7 +63,15 @@ export const ReferenceManyField = <
     props: ReferenceManyFieldProps<RecordType, ReferenceRecordType>
 ) => {
     const translate = useTranslate();
-    const { children, pagination, empty, ...controllerProps } = props;
+    const {
+        children,
+        pagination,
+        empty,
+        offline = defaultOffline,
+        render,
+        ...controllerProps
+    } = props;
+
     return (
         <ReferenceManyFieldBase<RecordType, ReferenceRecordType>
             {...controllerProps}
@@ -75,17 +84,35 @@ export const ReferenceManyField = <
                     empty
                 )
             }
-        >
-            {children}
-            {pagination}
-        </ReferenceManyFieldBase>
+            render={props => {
+                const { isPaused, isPending, isPlaceholderData } = props;
+                const shouldRenderOffline =
+                    isPaused &&
+                    (isPending || isPlaceholderData) &&
+                    offline !== undefined &&
+                    offline !== false;
+
+                return (
+                    <>
+                        {shouldRenderOffline
+                            ? offline
+                            : render
+                              ? render(props)
+                              : children}
+                        {pagination}
+                    </>
+                );
+            }}
+        />
     );
 };
+
+const defaultOffline = <Offline variant="inline" />;
 
 export interface ReferenceManyFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,
     ReferenceRecordType extends RaRecord = RaRecord,
 > extends Omit<FieldProps<RecordType>, 'source'>,
         ReferenceManyFieldBaseProps<RecordType, ReferenceRecordType> {
-    pagination?: React.ReactElement;
+    pagination?: React.ReactNode;
 }


### PR DESCRIPTION
## Problem

Our components and hooks can't leverage the offline support provided by Tanstack Query.

## Solution

- Make sure our data loading hooks returns the data needed to detect those cases
- Provide components, hooks and props allowing to handle offline scenarios
- Provide default offline components in `ra-ui-materialui`

## How To Test

- [`<ReferenceManyFieldBase>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-core-controller-field-referencemanyfieldbase--offline)
- [`<ReferenceManyField>`](https://react-admin-storybook-oyp7ya93k-marmelab.vercel.app/?path=/story/ra-ui-materialui-fields-referencemanyfield--offline) 
- Tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).