### PR TITLE
Fix regression regarding `disableAuthentication` in `EditBase` and `ShowBase`

### DIFF
--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -42,7 +42,6 @@ import { useIsAuthPending } from '../../auth';
  */
 export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
     children,
-    disableAuthentication,
     loading,
     offline,
     render,
@@ -65,7 +64,7 @@ export const EditBase = <RecordType extends RaRecord = any, ErrorType = Error>({
 
     const shouldRenderLoading =
         isAuthPending &&
-        !disableAuthentication &&
+        !props.disableAuthentication &&
         loading !== false &&
         loading !== undefined;
 

--- a/packages/ra-core/src/controller/show/ShowBase.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.tsx
@@ -41,7 +41,6 @@ import { useIsAuthPending } from '../../auth';
  */
 export const ShowBase = <RecordType extends RaRecord = any>({
     children,
-    disableAuthentication,
     loading,
     offline,
     render,
@@ -64,7 +63,7 @@ export const ShowBase = <RecordType extends RaRecord = any>({
 
     const shouldRenderLoading =
         isAuthPending &&
-        !disableAuthentication &&
+        !props.disableAuthentication &&
         loading !== false &&
         loading !== undefined;
 


### PR DESCRIPTION
## Problem

Previous offline PRs introduced a regression regarding `disableAuthentication` which is not passed to the controller anymore.

## Solution

Revert the destructuration of the `disableAuthentication` prop.

