### PR TITLE
Introduce `emptyWhileLoading` on `<ListBase>`

### DIFF
--- a/docs/ListBase.md
+++ b/docs/ListBase.md
@@ -84,7 +84,7 @@ The `<ListBase>` component accepts the following props:
 * [`debounce`](./List.md#debounce)
 * [`disableAuthentication`](./List.md#disableauthentication)
 * [`disableSyncWithLocation`](./List.md#disablesyncwithlocation)
-* [`emptyWhileLoading`](./List.md#emptyWhileLoading)
+* [`emptyWhileLoading`](./List.md#emptywhileloading)
 * [`exporter`](./List.md#exporter)
 * [`filter`](./List.md#filter-permanent-filter)
 * [`filterDefaultValues`](./List.md#filterdefaultvalues)

--- a/docs/ListBase.md
+++ b/docs/ListBase.md
@@ -84,6 +84,7 @@ The `<ListBase>` component accepts the following props:
 * [`debounce`](./List.md#debounce)
 * [`disableAuthentication`](./List.md#disableauthentication)
 * [`disableSyncWithLocation`](./List.md#disablesyncwithlocation)
+* [`emptyWhileLoading`](./List.md#emptyWhileLoading)
 * [`exporter`](./List.md#exporter)
 * [`filter`](./List.md#filter-permanent-filter)
 * [`filterDefaultValues`](./List.md#filterdefaultvalues)

--- a/packages/ra-core/src/controller/edit/EditBase.spec.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.spec.tsx
@@ -11,8 +11,12 @@ import {
     WithAuthProviderNoAccessControl,
     WithRenderProps,
 } from './EditBase.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('EditBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should give access to the save function', async () => {
         const dataProvider = testDataProvider({
             getOne: () =>

--- a/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceArrayFieldBase.spec.tsx
@@ -12,8 +12,12 @@ import { ReferenceArrayFieldBase } from './ReferenceArrayFieldBase';
 import { useResourceContext } from '../../core/useResourceContext';
 import { testDataProvider } from '../../dataProvider/testDataProvider';
 import { CoreAdminContext } from '../../core/CoreAdminContext';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ReferenceArrayFieldBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should display an error if error is defined', async () => {
         jest.spyOn(console, 'error')
             .mockImplementationOnce(() => {})

--- a/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceFieldBase.spec.tsx
@@ -14,10 +14,14 @@ import {
     WithRenderProp,
 } from './ReferenceFieldBase.stories';
 import { RecordContextProvider } from '../record';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('<ReferenceFieldBase />', () => {
     beforeAll(() => {
         window.scrollTo = jest.fn();
+    });
+    beforeEach(() => {
+        onlineManager.setOnline(true);
     });
 
     it('should display an error if error is defined', async () => {

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
@@ -6,8 +6,12 @@ import {
     LoadingState,
     Offline,
 } from './ReferenceManyCountBase.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ReferenceManyCountBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should display an error if error is defined', async () => {
         jest.spyOn(console, 'error')
             .mockImplementationOnce(() => {})

--- a/packages/ra-core/src/controller/field/ReferenceManyFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyFieldBase.spec.tsx
@@ -12,8 +12,12 @@ import { ReferenceManyFieldBase } from './ReferenceManyFieldBase';
 import { useResourceContext } from '../../core/useResourceContext';
 import { testDataProvider } from '../../dataProvider/testDataProvider';
 import { CoreAdminContext } from '../../core/CoreAdminContext';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ReferenceManyFieldBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should display an error if error is defined', async () => {
         jest.spyOn(console, 'error')
             .mockImplementationOnce(() => {})

--- a/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceOneFieldBase.spec.tsx
@@ -6,8 +6,12 @@ import {
     Offline,
     WithRenderProp,
 } from './ReferenceOneFieldBase.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ReferenceOneFieldBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should pass the loading state', async () => {
         jest.spyOn(console, 'error')
             .mockImplementationOnce(() => {})

--- a/packages/ra-core/src/controller/input/ReferenceArrayInputBase.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceArrayInputBase.spec.tsx
@@ -2,8 +2,12 @@ import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { testDataProvider } from 'ra-core';
 import { Basic, Offline, WithError } from './ReferenceArrayInputBase.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('<ReferenceArrayInputBase>', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     afterEach(async () => {
         // wait for the getManyAggregate batch to resolve
         await waitFor(() => new Promise(resolve => setTimeout(resolve, 0)));

--- a/packages/ra-core/src/controller/input/ReferenceInputBase.spec.tsx
+++ b/packages/ra-core/src/controller/input/ReferenceInputBase.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import expect from 'expect';
 import { render, screen, waitFor, fireEvent } from '@testing-library/react';
-import { QueryClient } from '@tanstack/react-query';
+import { onlineManager, QueryClient } from '@tanstack/react-query';
 import { CoreAdminContext } from '../../core';
 import {
     ChoicesProps,
@@ -29,6 +29,9 @@ describe('<ReferenceInputBase />', () => {
 
     beforeAll(() => {
         window.scrollTo = jest.fn();
+    });
+    beforeEach(() => {
+        onlineManager.setOnline(true);
     });
 
     it('should display an error if error is defined', async () => {

--- a/packages/ra-core/src/controller/list/ListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.spec.tsx
@@ -3,14 +3,19 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import {
     AccessControl,
     DefaultTitle,
+    EmptyWhileLoading,
     NoAuthProvider,
     Offline,
     WithAuthProviderNoAccessControl,
     WithRenderProps,
 } from './ListBase.stories';
 import { testDataProvider } from '../../dataProvider';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ListBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should load data immediately if authProvider is not provided', async () => {
         const dataProvider = testDataProvider({
             // @ts-ignore
@@ -144,7 +149,7 @@ describe('ListBase', () => {
     it('should render the offline prop node when offline', async () => {
         const { rerender } = render(<Offline isOnline={false} />);
         await screen.findByText('You are offline, cannot load data');
-        rerender(<Offline isOnline={true} />);
+        rerender(<Offline isOnline />);
         await screen.findByText('War and Peace');
         expect(
             screen.queryByText('You are offline, cannot load data')
@@ -153,11 +158,17 @@ describe('ListBase', () => {
         await screen.findByText('You are offline, the data may be outdated');
         fireEvent.click(screen.getByText('next'));
         await screen.findByText('You are offline, cannot load data');
-        rerender(<Offline isOnline={true} />);
+        rerender(<Offline isOnline />);
         await screen.findByText('And Then There Were None');
         rerender(<Offline isOnline={false} />);
         fireEvent.click(screen.getByText('previous'));
         await screen.findByText('War and Peace');
         await screen.findByText('You are offline, the data may be outdated');
+    });
+    it('should render nothing while loading if emptyWhileLoading is set to true', async () => {
+        render(<EmptyWhileLoading />);
+        expect(screen.queryByText('War and Peace')).toBeNull();
+        fireEvent.click(screen.getByText('Resolve books loading'));
+        await screen.findByText('War and Peace');
     });
 });

--- a/packages/ra-core/src/controller/list/ListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.spec.tsx
@@ -4,6 +4,7 @@ import {
     AccessControl,
     DefaultTitle,
     EmptyWhileLoading,
+    EmptyWhileLoadingRender,
     NoAuthProvider,
     Offline,
     WithAuthProviderNoAccessControl,
@@ -167,6 +168,12 @@ describe('ListBase', () => {
     });
     it('should render nothing while loading if emptyWhileLoading is set to true', async () => {
         render(<EmptyWhileLoading />);
+        expect(screen.queryByText('War and Peace')).toBeNull();
+        fireEvent.click(screen.getByText('Resolve books loading'));
+        await screen.findByText('War and Peace');
+    });
+    it('should render nothing while loading if emptyWhileLoading is set to true and using the render prop', async () => {
+        render(<EmptyWhileLoadingRender />);
         expect(screen.queryByText('War and Peace')).toBeNull();
         fireEvent.click(screen.getByText('Resolve books loading'));
         await screen.findByText('War and Peace');

--- a/packages/ra-core/src/controller/list/ListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.spec.tsx
@@ -168,6 +168,7 @@ describe('ListBase', () => {
     });
     it('should render nothing while loading if emptyWhileLoading is set to true', async () => {
         render(<EmptyWhileLoading />);
+        expect(screen.queryByText('Loading...')).toBeNull();
         expect(screen.queryByText('War and Peace')).toBeNull();
         fireEvent.click(screen.getByText('Resolve books loading'));
         await screen.findByText('War and Peace');

--- a/packages/ra-core/src/controller/list/ListBase.spec.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.spec.tsx
@@ -175,6 +175,7 @@ describe('ListBase', () => {
     });
     it('should render nothing while loading if emptyWhileLoading is set to true and using the render prop', async () => {
         render(<EmptyWhileLoadingRender />);
+        expect(screen.queryByText('Loading...')).toBeNull();
         expect(screen.queryByText('War and Peace')).toBeNull();
         fireEvent.click(screen.getByText('Resolve books loading'));
         await screen.findByText('War and Peace');

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -467,6 +467,46 @@ export const EmptyWhileLoading = () => {
     );
 };
 
+export const EmptyWhileLoadingRender = () => {
+    let resolveGetList: (() => void) | null = null;
+    const baseProvider = defaultDataProvider(0);
+    const dataProvider = {
+        ...baseProvider,
+        getList: (resource, params) => {
+            return new Promise<GetListResult>(resolve => {
+                resolveGetList = () =>
+                    resolve(baseProvider.getList(resource, params));
+            });
+        },
+    };
+
+    return (
+        <CoreAdminContext dataProvider={dataProvider}>
+            <button
+                onClick={() => {
+                    resolveGetList && resolveGetList();
+                }}
+            >
+                Resolve books loading
+            </button>
+            <ListBase
+                resource="books"
+                perPage={5}
+                emptyWhileLoading
+                render={({ data }) => {
+                    return (
+                        <ul>
+                            {data.map((record: any) => (
+                                <li key={record.id}>{record.title}</li>
+                            ))}
+                        </ul>
+                    );
+                }}
+            />
+        </CoreAdminContext>
+    );
+};
+
 const Title = () => {
     const { defaultTitle } = useListContext();
     const [locale, setLocale] = useLocaleState();

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -493,13 +493,17 @@ export const EmptyWhileLoadingRender = () => {
                 resource="books"
                 perPage={5}
                 emptyWhileLoading
-                render={({ data }) => (
-                    <ul>
-                        {data.map((record: any) => (
-                            <li key={record.id}>{record.title}</li>
-                        ))}
-                    </ul>
-                )}
+                render={({ isPending, data }) =>
+                    isPending ? (
+                        <p>Loading...</p>
+                    ) : (
+                        <ul>
+                            {data.map((record: any) => (
+                                <li key={record.id}>{record.title}</li>
+                            ))}
+                        </ul>
+                    )
+                }
             />
         </CoreAdminContext>
     );

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -9,6 +9,7 @@ import { useListContext } from './useListContext';
 import {
     AuthProvider,
     DataProvider,
+    GetListResult,
     I18nProvider,
     IsOffline,
     ListBaseProps,
@@ -51,11 +52,8 @@ const data = {
     ],
 };
 
-const defaultDataProvider = fakeRestProvider(
-    data,
-    process.env.NODE_ENV !== 'test',
-    300
-);
+const defaultDataProvider = (delay = 300) =>
+    fakeRestProvider(data, process.env.NODE_ENV !== 'test', delay);
 
 const BookListView = () => {
     const {
@@ -128,7 +126,7 @@ const BookListView = () => {
 };
 
 export const NoAuthProvider = ({
-    dataProvider = defaultDataProvider,
+    dataProvider = defaultDataProvider(),
 }: {
     dataProvider?: DataProvider;
 }) => (
@@ -146,7 +144,7 @@ export const WithAuthProviderNoAccessControl = ({
         checkAuth: () => new Promise(resolve => setTimeout(resolve, 300)),
         checkError: () => Promise.resolve(),
     },
-    dataProvider = defaultDataProvider,
+    dataProvider = defaultDataProvider(),
     ListProps,
 }: {
     authProvider?: AuthProvider;
@@ -173,7 +171,7 @@ export const AccessControl = ({
         checkError: () => Promise.resolve(),
         canAccess: () => new Promise(resolve => setTimeout(resolve, 300, true)),
     },
-    dataProvider = defaultDataProvider,
+    dataProvider = defaultDataProvider(),
 }: {
     authProvider?: AuthProvider;
     dataProvider?: DataProvider;
@@ -190,7 +188,7 @@ export const AccessControl = ({
 );
 
 export const SetParams = () => (
-    <CoreAdminContext dataProvider={defaultDataProvider}>
+    <CoreAdminContext dataProvider={defaultDataProvider()}>
         <ListBase resource="books" perPage={5}>
             <BookListView />
         </ListBase>
@@ -207,33 +205,33 @@ const ListMetadataInspector = () => {
     );
 };
 
-export const WithResponseMetadata = () => (
-    <CoreAdminContext
-        dataProvider={{
-            ...defaultDataProvider,
-            getList: async (resource, params) => {
-                const result = await defaultDataProvider.getList(
-                    resource,
-                    params
-                );
-                return {
-                    ...result,
-                    meta: {
-                        facets: [
-                            { value: 'bar', count: 2 },
-                            { value: 'baz', count: 1 },
-                        ],
-                    },
-                };
-            },
-        }}
-    >
-        <ListBase resource="books" perPage={5}>
-            <BookListView />
-            <ListMetadataInspector />
-        </ListBase>
-    </CoreAdminContext>
-);
+export const WithResponseMetadata = () => {
+    const dataProvider = defaultDataProvider();
+    return (
+        <CoreAdminContext
+            dataProvider={{
+                ...dataProvider,
+                getList: async (resource, params) => {
+                    const result = await dataProvider.getList(resource, params);
+                    return {
+                        ...result,
+                        meta: {
+                            facets: [
+                                { value: 'bar', count: 2 },
+                                { value: 'baz', count: 1 },
+                            ],
+                        },
+                    };
+                },
+            }}
+        >
+            <ListBase resource="books" perPage={5}>
+                <BookListView />
+                <ListMetadataInspector />
+            </ListBase>
+        </CoreAdminContext>
+    );
+};
 
 const defaultI18nProvider = polyglotI18nProvider(
     locale =>
@@ -283,7 +281,7 @@ export const DefaultTitle = ({
     translations?: 'default' | 'resource specific';
 }) => (
     <CoreAdminContext
-        dataProvider={defaultDataProvider}
+        dataProvider={defaultDataProvider()}
         i18nProvider={i18nProvider}
     >
         <ListBase resource="books" perPage={5}>
@@ -293,7 +291,7 @@ export const DefaultTitle = ({
 );
 
 export const WithRenderProps = ({
-    dataProvider = defaultDataProvider,
+    dataProvider = defaultDataProvider(),
 }: {
     dataProvider?: DataProvider;
 }) => (
@@ -358,7 +356,7 @@ DefaultTitle.argTypes = {
 };
 
 export const Offline = ({
-    dataProvider = defaultDataProvider,
+    dataProvider = defaultDataProvider(),
     isOnline = true,
     ...props
 }: {
@@ -438,6 +436,35 @@ Offline.argTypes = {
     isOnline: {
         control: { type: 'boolean' },
     },
+};
+
+export const EmptyWhileLoading = () => {
+    let resolveGetList: (() => void) | null = null;
+    const baseProvider = defaultDataProvider(0);
+    const dataProvider = {
+        ...baseProvider,
+        getList: (resource, params) => {
+            return new Promise<GetListResult>(resolve => {
+                resolveGetList = () =>
+                    resolve(baseProvider.getList(resource, params));
+            });
+        },
+    };
+
+    return (
+        <CoreAdminContext dataProvider={dataProvider}>
+            <button
+                onClick={() => {
+                    resolveGetList && resolveGetList();
+                }}
+            >
+                Resolve books loading
+            </button>
+            <ListBase resource="books" perPage={5} emptyWhileLoading>
+                <BookListView />
+            </ListBase>
+        </CoreAdminContext>
+    );
 };
 
 const Title = () => {

--- a/packages/ra-core/src/controller/list/ListBase.stories.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.stories.tsx
@@ -493,15 +493,13 @@ export const EmptyWhileLoadingRender = () => {
                 resource="books"
                 perPage={5}
                 emptyWhileLoading
-                render={({ data }) => {
-                    return (
-                        <ul>
-                            {data.map((record: any) => (
-                                <li key={record.id}>{record.title}</li>
-                            ))}
-                        </ul>
-                    );
-                }}
+                render={({ data }) => (
+                    <ul>
+                        {data.map((record: any) => (
+                            <li key={record.id}>{record.title}</li>
+                        ))}
+                    </ul>
+                )}
             />
         </CoreAdminContext>
     );

--- a/packages/ra-core/src/controller/list/ListBase.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.tsx
@@ -79,7 +79,7 @@ export const ListBase = <RecordType extends RaRecord = any>({
         offline !== undefined &&
         offline !== false;
 
-    const showEmpty = isPending && !showOffline && emptyWhileLoading;
+    const showEmpty = isPending && !showOffline && emptyWhileLoading === true;
 
     return (
         // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided

--- a/packages/ra-core/src/controller/list/ListBase.tsx
+++ b/packages/ra-core/src/controller/list/ListBase.tsx
@@ -46,9 +46,10 @@ import { useIsAuthPending } from '../../auth';
  */
 export const ListBase = <RecordType extends RaRecord = any>({
     children,
-    render,
+    emptyWhileLoading,
     loading,
     offline,
+    render,
     ...props
 }: ListBaseProps<RecordType>) => {
     const controllerProps = useListController<RecordType>(props);
@@ -78,6 +79,8 @@ export const ListBase = <RecordType extends RaRecord = any>({
         offline !== undefined &&
         offline !== false;
 
+    const showEmpty = isPending && !showOffline && emptyWhileLoading;
+
     return (
         // We pass props.resource here as we don't need to create a new ResourceContext if the props is not provided
         <OptionalResourceContextProvider value={props.resource}>
@@ -86,9 +89,11 @@ export const ListBase = <RecordType extends RaRecord = any>({
                     ? loading
                     : showOffline
                       ? offline
-                      : render
-                        ? render(controllerProps)
-                        : children}
+                      : showEmpty
+                        ? null
+                        : render
+                          ? render(controllerProps)
+                          : children}
             </ListContextProvider>
         </OptionalResourceContextProvider>
     );
@@ -97,7 +102,8 @@ export const ListBase = <RecordType extends RaRecord = any>({
 export interface ListBaseProps<RecordType extends RaRecord = any>
     extends ListControllerProps<RecordType> {
     children?: ReactNode;
-    render?: (props: ListControllerResult<RecordType, Error>) => ReactNode;
+    emptyWhileLoading?: boolean;
     loading?: ReactNode;
     offline?: ReactNode;
+    render?: (props: ListControllerResult<RecordType, Error>) => ReactNode;
 }

--- a/packages/ra-core/src/controller/show/ShowBase.spec.tsx
+++ b/packages/ra-core/src/controller/show/ShowBase.spec.tsx
@@ -11,8 +11,12 @@ import {
     WithAuthProviderNoAccessControl,
     WithRenderProp,
 } from './ShowBase.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ShowBase', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should load data immediately if authProvider is not provided', async () => {
         const dataProvider = testDataProvider({
             // @ts-ignore

--- a/packages/ra-core/src/core/IsOffline.spec.tsx
+++ b/packages/ra-core/src/core/IsOffline.spec.tsx
@@ -1,8 +1,12 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { Basic } from './IsOffline.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('<IsOffline>', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should render children when offline', async () => {
         const { rerender } = render(<Basic isOnline={false} />);
         await screen.findByText('You are offline, the data may be outdated');

--- a/packages/ra-ui-materialui/src/detail/Show.spec.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.spec.tsx
@@ -30,9 +30,11 @@ import {
 } from './Show.stories';
 import { Show } from './Show';
 import { Alert } from '@mui/material';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('<Show />', () => {
     beforeEach(async () => {
+        onlineManager.setOnline(true);
         // Why is this required? No idea, but without is the tests are flaky
         await new Promise(res => setTimeout(res, 100));
     });

--- a/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceArrayField.spec.tsx
@@ -31,10 +31,14 @@ import {
     WithPagination,
     WithRenderProp,
 } from './ReferenceArrayField.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 const theme = createTheme({});
 
 describe('<ReferenceArrayField />', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should render a loading indicator when related records are not yet fetched and a second has passed', async () => {
         render(
             <ThemeProvider theme={theme}>

--- a/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceField.spec.tsx
@@ -9,7 +9,7 @@ import {
     ResourceDefinitionContextProvider,
     AuthProvider,
 } from 'ra-core';
-import { QueryClient } from '@tanstack/react-query';
+import { onlineManager, QueryClient } from '@tanstack/react-query';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
 import { ReferenceField } from './ReferenceField';
@@ -36,6 +36,10 @@ const theme = createTheme({});
 
 describe('<ReferenceField />', () => {
     const record = { id: 123, postId: 123 };
+
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
 
     describe('Progress bar', () => {
         it("should not display a loader on mount if the reference is not in the store and a second hasn't passed yet", async () => {

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -10,8 +10,12 @@ import {
     Wrapper,
 } from './ReferenceManyCount.stories';
 import { ReferenceManyCount } from './ReferenceManyCount';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('<ReferenceManyCount />', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should return the number of related records of a given reference', async () => {
         render(<Basic />);
         await screen.findByText('3');

--- a/packages/ra-ui-materialui/src/field/ReferenceManyField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyField.spec.tsx
@@ -18,10 +18,14 @@ import {
     WithRenderProp,
 } from './ReferenceManyField.stories';
 import { Alert } from '@mui/material';
+import { onlineManager } from '@tanstack/react-query';
 
 const theme = createTheme();
 
 describe('<ReferenceManyField />', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     const defaultProps = {
         // resource and reference are the same because useReferenceManyFieldController
         // set the reference as the current resource

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.spec.tsx
@@ -12,8 +12,12 @@ import {
     WithRenderProp,
     Offline,
 } from './ReferenceOneField.stories';
+import { onlineManager } from '@tanstack/react-query';
 
 describe('ReferenceOneField', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should render the recordRepresentation of the related record', async () => {
         render(<RecordRepresentation />);
         await screen.findByText('Genre: novel, ISBN: 9780393966473');

--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -27,10 +27,14 @@ import {
     Offline,
 } from './List.stories';
 import { Alert } from '@mui/material';
+import { onlineManager } from '@tanstack/react-query';
 
 const theme = createTheme(defaultTheme);
 
 describe('<List />', () => {
+    beforeEach(() => {
+        onlineManager.setOnline(true);
+    });
     it('should render a list page', () => {
         const Datagrid = () => <div>datagrid</div>;
         const { container } = render(


### PR DESCRIPTION
## Problem

When using iterator like components as direct children of `ListBase`, they have to check the `isPending` state.

## Solution

- Introduce `emptyWhileLoading` on `<ListBase>` so they don't have to.
- Also fix offine tests impacting other tests

## How To Test

- [Story With Children](https://react-admin-storybook-i70jjdpns-marmelab.vercel.app/?path=/story/ra-core-controller-list-listbase--empty-while-loading)
- [Story With render prop](https://react-admin-storybook-i70jjdpns-marmelab.vercel.app/?path=/story/ra-core-controller-list-listbase--empty-while-loading-render)
- Unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
