### PR TITLE
Revert usage on `<ListIterator>` in `ra-ui-materialui`

### DIFF
--- a/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
+++ b/packages/ra-ui-materialui/src/list/SimpleList/SimpleList.tsx
@@ -13,8 +13,8 @@ import {
     useThemeProps,
 } from '@mui/material/styles';
 import {
-    ListIterator,
     type RaRecord,
+    RecordContextProvider,
     sanitizeListRestProps,
     useGetRecordRepresentation,
     useListContextWithProps,
@@ -122,10 +122,8 @@ export const SimpleList = <RecordType extends RaRecord = any>(
 
     return (
         <Root className={className} {...sanitizeListRestProps(rest)}>
-            <ListIterator<RecordType>
-                data={data}
-                total={total}
-                render={(record, rowIndex) => (
+            {data.map((record, rowIndex) => (
+                <RecordContextProvider key={record.id} value={record}>
                     <SimpleListItem
                         key={record.id}
                         rowIndex={rowIndex}
@@ -146,8 +144,8 @@ export const SimpleList = <RecordType extends RaRecord = any>(
                             rowIndex={rowIndex}
                         />
                     </SimpleListItem>
-                )}
-            />
+                </RecordContextProvider>
+            ))}
         </Root>
     );
 };

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.spec.tsx
@@ -5,7 +5,7 @@ import { ListContext, ResourceContextProvider } from 'ra-core';
 import { AdminContext } from '../AdminContext';
 import { SingleFieldList } from './SingleFieldList';
 import { ChipField } from '../field';
-import { Empty } from './SingleFieldList.stories';
+import { Divider, Empty } from './SingleFieldList.stories';
 
 describe('<SingleFieldList />', () => {
     it('should render a link to the Edit page of the related record by default', () => {
@@ -188,5 +188,13 @@ describe('<SingleFieldList />', () => {
             );
             expect(screen.queryByText('No genres')).toBeNull();
         });
+    });
+
+    it('should accept MUI Stack props', async () => {
+        render(<Divider />);
+        const item = await screen.findByText('Horror');
+        expect(
+            item.closest('.MuiStack-root').querySelectorAll('[data-separator]')
+        ).toHaveLength(2);
     });
 });

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.stories.tsx
@@ -146,7 +146,9 @@ export const Gap = () => (
 export const Divider = () => (
     <Wrapper>
         <SingleFieldList
-            divider={<MuiDivider orientation="vertical" flexItem />}
+            divider={
+                <MuiDivider orientation="vertical" data-separator flexItem />
+            }
         />
     </Wrapper>
 );

--- a/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
+++ b/packages/ra-ui-materialui/src/list/SingleFieldList.tsx
@@ -14,7 +14,7 @@ import {
     type RaRecord,
     RecordRepresentation,
     useCreatePath,
-    ListIterator,
+    RecordContextProvider,
 } from 'ra-core';
 
 import { LinearProgress } from '../layout/LinearProgress';
@@ -89,21 +89,21 @@ export const SingleFieldList = <RecordType extends RaRecord = any>(
             className={className}
             {...sanitizeListRestProps(rest)}
         >
-            <ListIterator<RecordType>
-                data={data}
-                total={total}
-                isPending={isPending}
-                render={record => {
-                    const resourceLinkPath = !linkType
-                        ? false
-                        : createPath({
-                              resource,
-                              type: linkType,
-                              id: record.id,
-                          });
+            {data.map((record, rowIndex) => {
+                const resourceLinkPath = !linkType
+                    ? false
+                    : createPath({
+                          resource,
+                          type: linkType,
+                          id: record.id,
+                      });
 
-                    if (resourceLinkPath) {
-                        return (
+                if (resourceLinkPath) {
+                    return (
+                        <RecordContextProvider
+                            value={record}
+                            key={record.id ?? `row${rowIndex}`}
+                        >
                             <Link
                                 className={SingleFieldListClasses.link}
                                 to={resourceLinkPath}
@@ -113,12 +113,19 @@ export const SingleFieldList = <RecordType extends RaRecord = any>(
                                     <DefaultChildComponent clickable />
                                 )}
                             </Link>
-                        );
-                    }
+                        </RecordContextProvider>
+                    );
+                }
 
-                    return children || <DefaultChildComponent />;
-                }}
-            />
+                return (
+                    <RecordContextProvider
+                        value={record}
+                        key={record.id ?? `row${rowIndex}`}
+                    >
+                        {children || <DefaultChildComponent />}
+                    </RecordContextProvider>
+                );
+            })}
         </Root>
     );
 };


### PR DESCRIPTION
Fixes #10900

## Problem

Using `<ListIterator>` in `ra-ui-materialui` introduced regressions.

## Solution

As we're in the process of rewriting `<ListIterator>` in `ra-core`, we chose to revert those changes for now.

## How To Test

- Current tests should work as before
- Added a test on `<SingleFieldList>` to detect regressions

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
