### PR TITLE
Fix inputs and fields label type

### DIFF
--- a/packages/ra-core/src/form/useInput.ts
+++ b/packages/ra-core/src/form/useInput.ts
@@ -1,4 +1,4 @@
-import { ReactElement, useEffect, useId, FocusEvent } from 'react';
+import { useEffect, useId, FocusEvent, ReactNode } from 'react';
 import {
     ControllerFieldState,
     ControllerRenderProps,
@@ -152,8 +152,8 @@ export type InputProps<ValueType = any> = Omit<
         format?: (value: ValueType) => any;
         id?: string;
         isRequired?: boolean;
-        label?: string | ReactElement | false;
-        helperText?: string | ReactElement | false;
+        label?: ReactNode;
+        helperText?: ReactNode;
         name?: string;
         onBlur?: (...event: any[]) => void;
         onChange?: (...event: any[]) => void;

--- a/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
+++ b/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
@@ -13,7 +13,7 @@ const TranslateLabel = ({
     resource,
 }: {
     source?: string;
-    label?: string | false | React.ReactElement;
+    label?: React.ReactNode;
     resource?: string;
 }) => {
     const translateLabel = useTranslateLabel();

--- a/packages/ra-ui-materialui/src/Labeled.tsx
+++ b/packages/ra-ui-materialui/src/Labeled.tsx
@@ -101,7 +101,7 @@ export interface LabeledProps extends StackProps {
     fullWidth?: boolean;
     htmlFor?: string;
     isRequired?: boolean;
-    label?: string | ReactElement | boolean;
+    label?: React.ReactNode;
     resource?: string;
     source?: string;
     TypographyProps?: TypographyProps;

--- a/packages/ra-ui-materialui/src/field/types.ts
+++ b/packages/ra-ui-materialui/src/field/types.ts
@@ -1,4 +1,4 @@
-import { ReactElement } from 'react';
+import { ReactNode } from 'react';
 import { TableCellProps } from '@mui/material/TableCell';
 import { BaseFieldProps, ExtractRecordPaths, HintedString } from 'ra-core';
 
@@ -38,7 +38,7 @@ export interface FieldProps<
      *     </List>
      * );
      */
-    label?: string | ReactElement | boolean;
+    label?: ReactNode;
 
     /**
      * Set it to false to disable the click handler on the column header when used inside <Datagrid>.

--- a/packages/ra-ui-materialui/src/input/InputHelperText.tsx
+++ b/packages/ra-ui-materialui/src/input/InputHelperText.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { isValidElement, ReactElement } from 'react';
+import { isValidElement } from 'react';
 import { useTranslate, ValidationError, ValidationErrorMessage } from 'ra-core';
 
 export const InputHelperText = (props: InputHelperTextProps) => {
@@ -33,6 +33,6 @@ export const InputHelperText = (props: InputHelperTextProps) => {
 const defaultInnerHTML = { __html: '&#8203;' };
 
 export interface InputHelperTextProps {
-    helperText?: string | ReactElement | boolean;
+    helperText?: React.ReactNode;
     error?: ValidationErrorMessage;
 }

--- a/packages/ra-ui-materialui/src/input/LoadingInput.tsx
+++ b/packages/ra-ui-materialui/src/input/LoadingInput.tsx
@@ -83,7 +83,7 @@ export interface LoadingInputProps {
     fullWidth?: boolean;
     helperText?: React.ReactNode;
     margin?: 'normal' | 'none' | 'dense';
-    label?: string | React.ReactElement | false;
+    label?: React.ReactNode;
     sx?: SxProps<Theme>;
     size?: 'medium' | 'small';
     timeout?: number;

--- a/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceArrayInput.tsx
@@ -92,6 +92,5 @@ export const ReferenceArrayInput = (props: ReferenceArrayInputProps) => {
 const defaultChildren = <AutocompleteArrayInput />;
 const defaultOffline = <Offline variant="inline" />;
 
-export interface ReferenceArrayInputProps extends ReferenceArrayInputBaseProps {
-    label?: string;
-}
+export interface ReferenceArrayInputProps
+    extends ReferenceArrayInputBaseProps {}


### PR DESCRIPTION
## Problem

The types for `label` and `helperText` are wrong: `string | ReactElement | false`. We actually accept `ReactNode` which includes `string` and `false`.

## Solution

Fix the types

## How To Test

- It should build correctly

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
