### PR TITLE
Introduce `useUpdateController`

### DIFF
--- a/packages/ra-core/src/controller/button/index.ts
+++ b/packages/ra-core/src/controller/button/index.ts
@@ -3,3 +3,4 @@ import useDeleteWithConfirmController from './useDeleteWithConfirmController';
 
 export { useDeleteWithUndoController, useDeleteWithConfirmController };
 export * from './useDeleteController';
+export * from './useUpdateController';

--- a/packages/ra-core/src/controller/button/useUpdateController.tsx
+++ b/packages/ra-core/src/controller/button/useUpdateController.tsx
@@ -1,0 +1,176 @@
+import { useCallback, useMemo } from 'react';
+import { useUpdate, UseUpdateOptions } from '../../dataProvider/useUpdate';
+import { useRedirect, RedirectionSideEffect } from '../../routing/useRedirect';
+import { useNotify } from '../../notification/useNotify';
+import { RaRecord, MutationMode } from '../../types';
+import { useRecordContext } from '../record/useRecordContext';
+import { useResourceContext } from '../../core/useResourceContext';
+import { useTranslate } from '../../i18n/useTranslate';
+
+/**
+ * Prepare a set of callbacks for an update button
+ *
+ * @example
+ * const UpdateButton = ({
+ *     resource,
+ *     record,
+ *     redirect,
+ *     ...rest
+ * }) => {
+ *     const {
+ *         isPending,
+ *         handleUpdate,
+ *     } = useUpdateController({
+ *         mutationMode: 'pessimistic',
+ *         resource,
+ *         record,
+ *         redirect,
+ *     });
+ *
+ *     const [open, setOpen] = useState(false);
+ *
+ *     return (
+ *         <Fragment>
+ *             <Button
+ *                 onClick={() => setOpen(true)}
+ *                 label="ra.action.update"
+ *                 {...rest}
+ *             >
+ *                 {icon}
+ *             </Button>
+ *             <Confirm
+ *                 isOpen={open}
+ *                 loading={isPending}
+ *                 title="ra.message.update_title"
+ *                 content="ra.message.update_content"
+ *                 titleTranslateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 contentTranslateOptions={{
+ *                     name: resource,
+ *                     id: record.id,
+ *                 }}
+ *                 onConfirm={() => handleUpdate()}
+ *                 onClose={() => setOpen(false)}
+ *             />
+ *         </Fragment>
+ *     );
+ * };
+ */
+export const useUpdateController = <
+    RecordType extends RaRecord = any,
+    ErrorType = Error,
+>(
+    props: UseUpdateControllerParams<RecordType, ErrorType>
+): UseUpdateControllerReturn => {
+    const {
+        redirect: redirectTo = false,
+        mutationMode,
+        mutationOptions = {},
+        successMessage,
+    } = props;
+    const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
+    const record = useRecordContext(props);
+    const resource = useResourceContext(props);
+    const notify = useNotify();
+    const redirect = useRedirect();
+    const translate = useTranslate();
+
+    const [updateOne, { isPending }] = useUpdate<RecordType, ErrorType>(
+        resource,
+        undefined,
+        {
+            onSuccess: () => {
+                notify(
+                    successMessage ??
+                        `resources.${resource}.notifications.updated`,
+                    {
+                        type: 'info',
+                        messageArgs: {
+                            smart_count: 1,
+                            _: translate('ra.notification.updated', {
+                                smart_count: 1,
+                            }),
+                        },
+                        undoable: mutationMode === 'undoable',
+                    }
+                );
+                redirect(redirectTo, resource);
+            },
+            onError: error => {
+                notify(
+                    typeof error === 'string'
+                        ? error
+                        : (error as Error)?.message ||
+                              'ra.notification.http_error',
+                    {
+                        type: 'error',
+                        messageArgs: {
+                            _:
+                                typeof error === 'string'
+                                    ? error
+                                    : (error as Error)?.message
+                                      ? (error as Error).message
+                                      : undefined,
+                        },
+                    }
+                );
+            },
+        }
+    );
+
+    const handleUpdate = useCallback(() => {
+        if (!record) {
+            throw new Error(
+                'The record cannot be updated because no record has been passed'
+            );
+        }
+        updateOne(
+            resource,
+            {
+                id: record.id,
+                previousData: record,
+                meta: mutationMeta,
+            },
+            {
+                mutationMode,
+                ...otherMutationOptions,
+            }
+        );
+    }, [
+        updateOne,
+        mutationMeta,
+        mutationMode,
+        otherMutationOptions,
+        record,
+        resource,
+    ]);
+
+    return useMemo(
+        () => ({
+            isPending,
+            isLoading: isPending,
+            handleUpdate,
+        }),
+        [isPending, handleUpdate]
+    );
+};
+
+export interface UseUpdateControllerParams<
+    RecordType extends RaRecord = any,
+    MutationOptionsError = unknown,
+> {
+    mutationMode?: MutationMode;
+    mutationOptions?: UseUpdateOptions<RecordType, MutationOptionsError>;
+    record?: RecordType;
+    redirect?: RedirectionSideEffect;
+    resource?: string;
+    successMessage?: string;
+}
+
+export interface UseUpdateControllerReturn {
+    isLoading: boolean;
+    isPending: boolean;
+    handleUpdate: () => void;
+}

--- a/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
@@ -6,18 +6,15 @@ import {
 } from '@mui/material/styles';
 import ActionUpdate from '@mui/icons-material/Update';
 import {
-    useRefresh,
-    useNotify,
     useResourceContext,
     type RaRecord,
     useRecordContext,
-    useUpdate,
-    type UpdateParams,
     useTranslate,
     useGetRecordRepresentation,
     useResourceTranslation,
+    useUpdateController,
+    UseUpdateControllerParams,
 } from 'ra-core';
-import type { UseMutationOptions } from '@tanstack/react-query';
 import { humanize, singularize } from 'inflection';
 
 import { Button, type ButtonProps } from './Button';
@@ -28,18 +25,16 @@ export const UpdateWithUndoButton = (inProps: UpdateWithUndoButtonProps) => {
         name: PREFIX,
     });
     const record = useRecordContext(props);
-    const notify = useNotify();
     const resource = useResourceContext(props);
-    const refresh = useRefresh();
 
     const {
         data,
         label: labelProp,
         icon = defaultIcon,
         onClick,
-        mutationOptions = {},
         ...rest
     } = props;
+    const { handleUpdate, isPending } = useUpdateController(rest);
     const translate = useTranslate();
     const getRecordRepresentation = useGetRecordRepresentation(resource);
     let recordRepresentation = getRecordRepresentation(record);
@@ -66,41 +61,6 @@ export const UpdateWithUndoButton = (inProps: UpdateWithUndoButtonProps) => {
         },
         userText: labelProp,
     });
-    const [updateMany, { isPending }] = useUpdate();
-
-    const {
-        meta: mutationMeta,
-        onSuccess = () => {
-            notify(`resources.${resource}.notifications.updated`, {
-                type: 'info',
-                messageArgs: {
-                    smart_count: 1,
-                    _: translate('ra.notification.updated', { smart_count: 1 }),
-                },
-                undoable: true,
-            });
-        },
-        onError = (error: Error | string) => {
-            notify(
-                typeof error === 'string'
-                    ? error
-                    : error.message || 'ra.notification.http_error',
-                {
-                    type: 'error',
-                    messageArgs: {
-                        _:
-                            typeof error === 'string'
-                                ? error
-                                : error && error.message
-                                  ? error.message
-                                  : undefined,
-                    },
-                }
-            );
-            refresh();
-        },
-        ...otherMutationOptions
-    } = mutationOptions;
 
     const handleClick = e => {
         if (!record) {
@@ -108,16 +68,7 @@ export const UpdateWithUndoButton = (inProps: UpdateWithUndoButtonProps) => {
                 'The UpdateWithUndoButton must be used inside a RecordContext.Provider or must be passed a record prop.'
             );
         }
-        updateMany(
-            resource,
-            { id: record.id, data, meta: mutationMeta, previousData: record },
-            {
-                onSuccess,
-                onError,
-                mutationMode: 'undoable',
-                ...otherMutationOptions,
-            }
-        );
+        handleUpdate();
         if (typeof onClick === 'function') {
             onClick(e);
         }
@@ -149,14 +100,10 @@ const sanitizeRestProps = ({
 export interface UpdateWithUndoButtonProps<
     RecordType extends RaRecord = any,
     MutationOptionsError = unknown,
-> extends ButtonProps {
+> extends ButtonProps,
+        UseUpdateControllerParams<RecordType, MutationOptionsError> {
     icon?: React.ReactNode;
     data: any;
-    mutationOptions?: UseMutationOptions<
-        RecordType,
-        MutationOptionsError,
-        UpdateParams<RecordType>
-    > & { meta?: any };
 }
 
 const PREFIX = 'RaUpdateWithUndoButton';


### PR DESCRIPTION
## Problem

Just like the <DeleteButton> we want a controller hook that ease the implementation in custom UIs.

## Solution

Introduce `useUpdateController`

## How To Test

- `<UpdateButton>` should work as before

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
