### PR TITLE
[chore] Fix release script uses a deprecated GitHub API

### DIFF
--- a/scripts/update-changelog.ts
+++ b/scripts/update-changelog.ts
@@ -67,6 +67,7 @@ const fetchMilestonePrs = async (milestone_number: string) => {
     >;
     try {
         milestone_prs = await octokit.request('GET /search/issues', {
+            advanced_search: true,
             q: `repo:marmelab/react-admin is:pr milestone:${milestone_number}`,
             headers: {
                 'X-GitHub-Api-Version': '2022-11-28',


### PR DESCRIPTION
## Problem

Release script raises the following warning:

```
[@octokit/request] "GET https://api.github.com/search/issues?q=repo%3Amarmelab%2Freact-admin%20is%3Apr%20milestone%3A5.10.2" is deprecated. It is scheduled to be removed on Thu, 04 Sep 2025 00:00:00 GMT. See https://github.blog/changelog/2025-03-06-github-issues-projects-api-support-for-issues-advanced-search-and-more/
```

## Solution

Enable [advanced search](https://docs.github.com/en/rest/search/search?apiVersion=2022-11-28#search-issues-and-pull-requests) to remove the warning.

## How To Test

`yarn run update-changelog 5.10.2`
shows the warning before, no longer shows it after fix

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
