### PR TITLE
Fix BulkDeleteWithConfirmButton color

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -119,6 +119,7 @@ export const BulkDeleteWithConfirmButton = (
             <StyledButton
                 onClick={handleClick}
                 label={label}
+                color="error"
                 {...sanitizeRestProps(rest)}
             >
                 {icon}


### PR DESCRIPTION
## Problem

BulkDeleteWithConfirmButton has different color than BulkDeleteWithUndoButton.

## Solution

Use the same color for both buttons.

## How To Test

Include both buttons in a `bulkActionButtons` prop and visually compare.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
