### PR TITLE
Fix `RaDataTable-rowCell` CSS class is not applied on `<DataTable>` cells

### DIFF
--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.stories.tsx
@@ -239,6 +239,9 @@ export const SX = () => (
                 '& .RaDataTable-rowOdd': {
                     backgroundColor: '#fee',
                 },
+                '& .RaDataTable-rowCell': {
+                    color: 'red',
+                },
             }}
         >
             <DataTable.Col source="id" />

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableCell.tsx
@@ -6,6 +6,7 @@ import get from 'lodash/get';
 import clsx from 'clsx';
 
 import { DataTableColumnProps } from './DataTableColumn';
+import { DataTableClasses } from './DataTableRoot';
 
 const PREFIX = 'RaDataTableCell';
 
@@ -55,6 +56,7 @@ export const DataTableCell = React.memo(
                 <TableCellStyled
                     ref={ref}
                     className={clsx(
+                        DataTableClasses.rowCell,
                         className,
                         cellClassName,
                         `column-${source}`


### PR DESCRIPTION
## Problem

It's not possible to customize the styles of `<DataTable>` cells by following the [documentation](https://marmelab.com/react-admin/DataTable.html#sx-css-api).

## Solution

Apply the `RaDataTable-rowCell` CSS class to `<DataTableCell>`

## How To Test

- [Story](https://react-admin-storybook-6bbr3ecng-marmelab.vercel.app/?path=/story/ra-ui-materialui-list-datatable--sx)
- The cells should have a red text color

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
~~- [ ] The PR includes **unit tests** (if not possible, describe why)~~ Design only
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
