### PR TITLE
docs: Update disable sorting property in DataTable documentation

### DIFF
--- a/docs/DataTable.md
+++ b/docs/DataTable.md
@@ -1607,7 +1607,7 @@ The column headers are buttons that allow users to change the list sort field an
 
 ### Disabling Sorting
 
-It is possible to disable sorting for a specific `<DataTable.Col>` by passing a `sortable` property set to `false`:
+It is possible to disable sorting for a specific `<DataTable.Col>` by passing the `disableSort` property:
 
 {% raw %}
 ```tsx
@@ -1617,7 +1617,7 @@ import { List, DataTable } from 'react-admin';
 export const PostList = () => (
     <List>
         <DataTable>
-            <DataTable.Col source="id" sortable={false} />
+            <DataTable.Col source="id" disableSort />
             <DataTable.Col source="title" />
             <DataTable.Col source="body" />
         </DataTable>


### PR DESCRIPTION
## Problem

Fixes #10942.

## Solution

I just updated the documentation.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
