### PR TITLE
Fix `useLogout` does not redirect to the `checkAuth` call `redirectTo` property

### DIFF
--- a/packages/ra-core/src/auth/useLogout.spec.tsx
+++ b/packages/ra-core/src/auth/useLogout.spec.tsx
@@ -7,6 +7,7 @@ import expect from 'expect';
 import { useGetOne } from '../dataProvider';
 import useLogout from './useLogout';
 import { CoreAdminContext } from '../core/CoreAdminContext';
+import { Redirect } from './useLogout.stories';
 
 import { TestMemoryRouter } from '../routing';
 
@@ -54,98 +55,21 @@ describe('useLogout', () => {
         ).toBeUndefined();
     });
     it('should redirect to `/login` by default', async () => {
-        const LogoutButton = () => {
-            const logout = useLogout();
-            return <button onClick={logout}>Logout</button>;
-        };
-        const authProvider = {
-            logout: () => Promise.resolve(),
-        } as any;
-        const Page = () => <div>Page</div>;
-        const Login = () => <div>Login</div>;
-        render(
-            <TestMemoryRouter>
-                <CoreAdminContext authProvider={authProvider}>
-                    <Routes>
-                        <Route path="/" element={<Page />} />
-                        <Route path="/login" element={<Login />} />
-                    </Routes>
-
-                    <LogoutButton />
-                </CoreAdminContext>
-            </TestMemoryRouter>
-        );
+        render(<Redirect redirectTo="default" />);
         await screen.findByText('Page');
         fireEvent.click(screen.getByText('Logout'));
         await screen.findByText('Login');
     });
     it('should redirect to the url returned by the authProvider.logout call', async () => {
-        const LogoutButton = () => {
-            const logout = useLogout();
-            return <button onClick={logout}>Logout</button>;
-        };
-        const authProvider = {
-            logout: () => Promise.resolve('/not_login'),
-        } as any;
-        const queryClient = new QueryClient();
-        const Page = () => <div>Page</div>;
-        const Login = () => <div>Login</div>;
-        const NotLogin = () => <div>NotLogin</div>;
-        render(
-            <TestMemoryRouter>
-                <CoreAdminContext
-                    authProvider={authProvider}
-                    queryClient={queryClient}
-                >
-                    <Routes>
-                        <Route path="/" element={<Page />} />
-                        <Route path="/login" element={<Login />} />
-                        <Route path="/not_login" element={<NotLogin />} />
-                    </Routes>
-
-                    <LogoutButton />
-                </CoreAdminContext>
-            </TestMemoryRouter>
-        );
+        render(<Redirect redirectTo="authProvider.logout" />);
         await screen.findByText('Page');
         fireEvent.click(screen.getByText('Logout'));
-        await screen.findByText('NotLogin');
+        await screen.findByText('Custom from authProvider.logout');
     });
     it('should redirect to the url returned by the caller', async () => {
-        const LogoutButton = () => {
-            const logout = useLogout();
-            return (
-                <button onClick={() => logout(undefined, '/caller_redirect')}>
-                    Logout
-                </button>
-            );
-        };
-        const authProvider = {
-            logout: () => Promise.resolve('/not_login'),
-        } as any;
-        const Page = () => <div>Page</div>;
-        const Login = () => <div>Login</div>;
-        const NotLogin = () => <div>NotLogin</div>;
-        const CallerRedirect = () => <div>CallerRedirect</div>;
-        render(
-            <TestMemoryRouter>
-                <CoreAdminContext authProvider={authProvider}>
-                    <Routes>
-                        <Route path="/" element={<Page />} />
-                        <Route path="/login" element={<Login />} />
-                        <Route path="/not_login" element={<NotLogin />} />
-                        <Route
-                            path="/caller_redirect"
-                            element={<CallerRedirect />}
-                        />
-                    </Routes>
-
-                    <LogoutButton />
-                </CoreAdminContext>
-            </TestMemoryRouter>
-        );
+        render(<Redirect redirectTo="caller" />);
         await screen.findByText('Page');
         fireEvent.click(screen.getByText('Logout'));
-        await screen.findByText('CallerRedirect');
+        await screen.findByText('Custom from useLogout caller');
     });
 });

--- a/packages/ra-core/src/auth/useLogout.spec.tsx
+++ b/packages/ra-core/src/auth/useLogout.spec.tsx
@@ -53,4 +53,99 @@ describe('useLogout', () => {
             queryClient.getQueryData(['posts', 'getOne', { id: '1' }])
         ).toBeUndefined();
     });
+    it('should redirect to `/login` by default', async () => {
+        const LogoutButton = () => {
+            const logout = useLogout();
+            return <button onClick={logout}>Logout</button>;
+        };
+        const authProvider = {
+            logout: () => Promise.resolve(),
+        } as any;
+        const Page = () => <div>Page</div>;
+        const Login = () => <div>Login</div>;
+        render(
+            <TestMemoryRouter>
+                <CoreAdminContext authProvider={authProvider}>
+                    <Routes>
+                        <Route path="/" element={<Page />} />
+                        <Route path="/login" element={<Login />} />
+                    </Routes>
+
+                    <LogoutButton />
+                </CoreAdminContext>
+            </TestMemoryRouter>
+        );
+        await screen.findByText('Page');
+        fireEvent.click(screen.getByText('Logout'));
+        await screen.findByText('Login');
+    });
+    it('should redirect to the url returned by the authProvider.logout call', async () => {
+        const LogoutButton = () => {
+            const logout = useLogout();
+            return <button onClick={logout}>Logout</button>;
+        };
+        const authProvider = {
+            logout: () => Promise.resolve('/not_login'),
+        } as any;
+        const queryClient = new QueryClient();
+        const Page = () => <div>Page</div>;
+        const Login = () => <div>Login</div>;
+        const NotLogin = () => <div>NotLogin</div>;
+        render(
+            <TestMemoryRouter>
+                <CoreAdminContext
+                    authProvider={authProvider}
+                    queryClient={queryClient}
+                >
+                    <Routes>
+                        <Route path="/" element={<Page />} />
+                        <Route path="/login" element={<Login />} />
+                        <Route path="/not_login" element={<NotLogin />} />
+                    </Routes>
+
+                    <LogoutButton />
+                </CoreAdminContext>
+            </TestMemoryRouter>
+        );
+        await screen.findByText('Page');
+        fireEvent.click(screen.getByText('Logout'));
+        await screen.findByText('NotLogin');
+    });
+    it('should redirect to the url returned by the caller', async () => {
+        const LogoutButton = () => {
+            const logout = useLogout();
+            return (
+                <button onClick={() => logout(undefined, '/caller_redirect')}>
+                    Logout
+                </button>
+            );
+        };
+        const authProvider = {
+            logout: () => Promise.resolve('/not_login'),
+        } as any;
+        const Page = () => <div>Page</div>;
+        const Login = () => <div>Login</div>;
+        const NotLogin = () => <div>NotLogin</div>;
+        const CallerRedirect = () => <div>CallerRedirect</div>;
+        render(
+            <TestMemoryRouter>
+                <CoreAdminContext authProvider={authProvider}>
+                    <Routes>
+                        <Route path="/" element={<Page />} />
+                        <Route path="/login" element={<Login />} />
+                        <Route path="/not_login" element={<NotLogin />} />
+                        <Route
+                            path="/caller_redirect"
+                            element={<CallerRedirect />}
+                        />
+                    </Routes>
+
+                    <LogoutButton />
+                </CoreAdminContext>
+            </TestMemoryRouter>
+        );
+        await screen.findByText('Page');
+        fireEvent.click(screen.getByText('Logout'));
+        await screen.findByText('CallerRedirect');
+    });
 });

--- a/packages/ra-core/src/auth/useLogout.stories.tsx
+++ b/packages/ra-core/src/auth/useLogout.stories.tsx
@@ -1,0 +1,75 @@
+import * as React from 'react';
+import { Route, Routes } from 'react-router';
+import { TestMemoryRouter } from '../routing/TestMemoryRouter';
+import { CoreAdminContext } from '../core/CoreAdminContext';
+import useLogout from './useLogout';
+
+export default {
+    title: 'ra-core/auth/useLogout',
+};
+
+export const Redirect = ({
+    redirectTo,
+}: {
+    redirectTo: 'default' | 'authProvider.logout' | 'caller';
+}) => {
+    const authProvider = {
+        logout: () =>
+            Promise.resolve(
+                redirectTo === 'authProvider.logout'
+                    ? '/logout_redirect'
+                    : undefined
+            ),
+    } as any;
+
+    return (
+        <TestMemoryRouter key={redirectTo}>
+            <CoreAdminContext authProvider={authProvider}>
+                <Routes>
+                    <Route path="/" element={<div>Page</div>} />
+                    <Route path="/login" element={<div>Login</div>} />
+                    <Route
+                        path="/logout_redirect"
+                        element={<div>Custom from authProvider.logout</div>}
+                    />
+                    <Route
+                        path="/caller_redirect"
+                        element={<div>Custom from useLogout caller</div>}
+                    />
+                </Routes>
+
+                <LogoutButton
+                    redirectTo={
+                        redirectTo === 'caller' ? '/caller_redirect' : undefined
+                    }
+                />
+            </CoreAdminContext>
+        </TestMemoryRouter>
+    );
+};
+
+Redirect.args = {
+    redirectTo: 'default',
+};
+
+Redirect.argTypes = {
+    redirectTo: {
+        type: 'string',
+        options: ['default', 'authProvider.logout', 'caller'],
+        mapping: {
+            default: undefined,
+            'authProvider.logout': 'authProvider.logout',
+            caller: 'caller',
+        },
+        control: {
+            type: 'radio',
+        },
+    },
+};
+
+const LogoutButton = ({ redirectTo }: { redirectTo?: string }) => {
+    const logout = useLogout();
+    return (
+        <button onClick={() => logout(undefined, redirectTo)}>Logout</button>
+    );
+};


### PR DESCRIPTION
## Problem

The [documentation](https://marmelab.com/react-admin/AuthProviderWriting.html#checkauth) says:
> If both `authProvider.checkAuth()` and `authProvider.logout()` return a redirect URL, the one from `authProvider.checkAuth()` takes precedence.

However, the code actually does the opposite. This is an issue when you want to redirect to a custom `/access-denied` page.

## Solution

- Fix `useLogout` to behave as expected.

## How To Test

- Unit tests
- [Story]()

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
