### PR TITLE
RFC: feat: add `selectionStoreKey` to List

### DIFF
--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -57,6 +57,7 @@ export const useListController = <
         filterDefaultValues,
         perPage = 10,
         queryOptions = {},
+        selectionStoreKey,
         sort = defaultSort,
         storeKey,
     } = props;
@@ -101,10 +102,19 @@ export const useListController = <
         storeKey,
     });
 
-    const [selectedIds, selectionModifiers] = useRecordSelection({
-        resource,
-        disableSyncWithStore: storeKey === false,
-    });
+    const [selectedIds, selectionModifiers] = useRecordSelection(
+        selectionStoreKey
+            ? {
+                  storeKey: selectionStoreKey,
+              }
+            : storeKey === false
+              ? {
+                    disableSyncWithStore: true,
+                }
+              : {
+                    resource,
+                }
+    );
 
     const {
         data,
@@ -440,6 +450,23 @@ export interface ListControllerProps<
      * );
      */
     storeKey?: string | false;
+
+    /**
+     * The key to use to store selected items. Pass undefined to use default key.
+     *
+     * @see https://marmelab.com/react-admin/List.html#selectionStorekey
+     * @example
+     * const NewerBooks = () => (
+     *     <List
+     *         resource="books"
+     *         selectionStoreKey="newerBooks"
+     *         sort={{ field: 'year', order: 'DESC' }}
+     *     >
+     *         ...
+     *     </List>
+     * );
+     */
+    selectionStoreKey?: string;
 }
 
 const defaultSort = {

--- a/packages/ra-core/src/controller/list/useRecordSelection.ts
+++ b/packages/ra-core/src/controller/list/useRecordSelection.ts
@@ -3,16 +3,24 @@ import { useCallback, useMemo, useState } from 'react';
 import { useStore, useRemoveFromStore } from '../../store';
 import { RaRecord } from '../../types';
 
+type UseRecordSelectionWithStoreKeyArgs = {
+    storeKey: string;
+    resource?: string;
+    disableSyncWithStore?: false;
+};
 type UseRecordSelectionWithResourceArgs = {
+    storeKey?: string;
     resource: string;
     disableSyncWithStore?: false;
 };
 type UseRecordSelectionWithNoStoreArgs = {
+    storeKey?: string;
     resource?: string;
     disableSyncWithStore: true;
 };
 
 export type UseRecordSelectionArgs =
+    | UseRecordSelectionWithStoreKeyArgs
     | UseRecordSelectionWithResourceArgs
     | UseRecordSelectionWithNoStoreArgs;
 
@@ -29,6 +37,7 @@ export type UseRecordSelectionResult<RecordType extends RaRecord = any> = [
 /**
  * Get the list of selected items for a resource, and callbacks to change the selection
  *
+ * @param args.storeKey The key to use to store the selected items
  * @param args.resource The resource name, e.g. 'posts'
  * @param args.disableSyncWithStore Controls the selection syncronization with the store
  *
@@ -37,19 +46,19 @@ export type UseRecordSelectionResult<RecordType extends RaRecord = any> = [
 export const useRecordSelection = <RecordType extends RaRecord = any>(
     args: UseRecordSelectionArgs
 ): UseRecordSelectionResult<RecordType> => {
-    const { resource = '', disableSyncWithStore = false } = args;
+    const { storeKey, resource = '', disableSyncWithStore = false } = args;
 
-    const storeKey = `${resource}.selectedIds`;
+    const finalStoreKey = storeKey || `${resource}.selectedIds`;
 
     const [localIds, setLocalIds] =
         useState<RecordType['id'][]>(defaultSelection);
     // As we can't conditionally call a hook, if the storeKey is false,
     // we'll ignore the params variable later on and won't call setParams either.
     const [storeIds, setStoreIds] = useStore<RecordType['id'][]>(
-        storeKey,
+        finalStoreKey,
         defaultSelection
     );
-    const resetStore = useRemoveFromStore(storeKey);
+    const resetStore = useRemoveFromStore(finalStoreKey);
 
     const ids = disableSyncWithStore ? localIds : storeIds;
     const setIds = disableSyncWithStore ? setLocalIds : setStoreIds;

--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -72,6 +72,7 @@ export const List = <RecordType extends RaRecord = any>(
         perPage = 10,
         queryOptions,
         resource,
+        selectionStoreKey,
         sort,
         storeKey,
         render,
@@ -100,6 +101,7 @@ export const List = <RecordType extends RaRecord = any>(
             perPage={perPage}
             queryOptions={queryOptions}
             resource={resource}
+            selectionStoreKey={selectionStoreKey}
             sort={sort}
             storeKey={storeKey}
             // Disable offline support from ListBase as it is handled by ListView to keep the ListView container


### PR DESCRIPTION
## Problem

It's not possible to create distinct List views that use separate and independent record selection states.

## Solution

Add `selectionStoreKey` to List, useListController and, eventually, to useRecordSelection. If passed, it's used inside useRecordSelection as store key.