### PR TITLE
[Doc] Add missing props to `<ReferenceArrayFieldBase>` and `<ReferenceManyFieldBase>` documentation

### DIFF
--- a/docs/ReferenceArrayFieldBase.md
+++ b/docs/ReferenceArrayFieldBase.md
@@ -91,7 +91,10 @@ You can change how the list of related records is rendered by passing a custom c
 | `reference`    | Required | `string`                                                                          | -                                | The name of the resource for the referenced records, e.g. 'tags'                                       |
 | `children`     | Optional\* | `Element`                                                                         |               | One or several elements that render a list of records based on a `ListContext`                         |
 | `render`     | Optional\* | `(ListContext) => Element`                                                                         |               | A function that takes a list context and renders a list of records                        |
+| `empty`        | Optional | `ReactNode`                                                                       | -                                | The component to render when the related records list is empty                                         |
+| `error`        | Optional | `ReactNode`                                                                       | -                                | The component to render when an error occurs while fetching the related records                        |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records (the filtering is done client-side)                   |
+| `loading`      | Optional | `ReactNode`                                                                       | -                                | The component to render while fetching the related records                                             |
 | `offline`      | Optional | `ReactNode`                                                              |              | The component to render when there is no connectivity and the record isn't in the cache |
 | `perPage`      | Optional | `number`                                                                          | 1000                             | Maximum number of results to display                                                                   |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                                                           |
@@ -127,6 +130,70 @@ const TagList = (props: { children: React.ReactNode }) => {
         </p>
     );
 };
+```
+
+## `empty`
+
+By default, `<ReferenceArrayFieldBase>` renders its children even when the related records list is empty. You can customize what is rendered by providing your own component via the `empty` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'react-admin';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            empty={<p>No tags found.</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    empty={null}
+>
+    ...
+</ReferenceArrayFieldBase>
+```
+
+## `error`
+
+By default, `<ReferenceArrayFieldBase>` renders its children even when an error occurs while fetching the related records. You can customize what is rendered by providing your own component via the `error` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'react-admin';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            error={<p>Error loading tags. Please try again.</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    error={null}
+>
+    ...
+</ReferenceArrayFieldBase>
 ```
 
 ## `render`
@@ -176,12 +243,44 @@ For instance, to render only tags that are 'published', you can use the followin
 ```
 {% endraw %}
 
+## `loading`
+
+By default, `<ReferenceArrayFieldBase>` renders its children even while fetching the related records. You can customize what is rendered by providing your own component via the `loading` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'react-admin';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            loading={<p>Loading tags...</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    loading={null}
+>
+    ...
+</ReferenceArrayFieldBase>
+```
+
 ## `offline`
 
 By default, `<ReferenceArrayFieldBase>` renders nothing when there is no connectivity and the records haven't been cached yet. You can provide your own component via the `offline` prop:
 
 ```jsx
-import { ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+import { ReferenceArrayFieldBase, ShowBase } from 'react-admin';
 
 export const PostShow = () => (
     <ShowBase>
@@ -199,7 +298,7 @@ export const PostShow = () => (
 **Tip**: If the records are in the Tanstack Query cache but you want to warn the user that they may see an outdated version, you can use the `<IsOffline>` component:
 
 ```jsx
-import { IsOffline, ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+import { IsOffline, ReferenceArrayFieldBase, ShowBase } from 'react-admin';
 
 export const PostShow = () => (
     <ShowBase>

--- a/docs/ReferenceManyFieldBase.md
+++ b/docs/ReferenceManyFieldBase.md
@@ -89,11 +89,13 @@ export const PostList = () => (
 
 | Prop           | Required | Type                                                                              | Default                          | Description                                                                         |
 | -------------- | -------- | --------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| `children`     | Optional | `Element`                                                                         | -                                | One or several elements that render a list of records based on a `ListContext`      |
+| `children`     | Optional\* | `Element`                                                                         | -                                | One or several elements that render a list of records based on a `ListContext`      |
 | `render`     | Optional\* | `(ListContext) => Element`                                                                         | -                                | Function that receives a `ListContext` and returns an element      |
-| `debounce`     | Optional\* | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
+| `debounce`     | Optional | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
 | `empty`        | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records.                                |
+| `error`        | Optional | `ReactNode`                                                                       | -                                | The component to render when an error occurs while fetching the related records     |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records, passed to `getManyReference()`    |
+| `loading`      | Optional | `ReactNode`                                                                       | -                                | The component to render while fetching the related records                          |
 | `offline`      | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records because of lack of network connectivity. |
 | `perPage`      | Optional | `number`                                                                          | 25                               | Maximum number of referenced records to fetch                                       |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                       |
@@ -177,6 +179,38 @@ Use `empty` to customize the text displayed when there are no related records.
 </ReferenceManyFieldBase>
 ```
 
+## `error`
+
+By default, `<ReferenceManyFieldBase>` renders its children when an error occurs while fetching the related records. You can customize what is rendered by providing your own component via the `error` prop:
+
+```jsx
+import { ReferenceManyFieldBase, ShowBase } from 'react-admin';
+
+export const AuthorShow = () => (
+    <ShowBase>
+        <ReferenceManyFieldBase
+            reference="books"
+            target="author_id"
+            error={<p>Error loading books. Please try again.</p>}
+        >
+            ...
+        </ReferenceManyFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceManyFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    error={null}
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
 ## `filter`: Permanent Filter
 
 You can filter the query used to populate the possible values. Use the `filter` prop for that.
@@ -194,6 +228,38 @@ You can filter the query used to populate the possible values. Use the `filter` 
 ```
 
 {% endraw %}
+
+## `loading`
+
+By default, `<ReferenceManyFieldBase>` renders its children while fetching the related records. You can customize what is rendered by providing your own component via the `loading` prop:
+
+```jsx
+import { ReferenceManyFieldBase, ShowBase } from 'react-admin';
+
+export const AuthorShow = () => (
+    <ShowBase>
+        <ReferenceManyFieldBase
+            reference="books"
+            target="author_id"
+            loading={<p>Loading books...</p>}
+        >
+            ...
+        </ReferenceManyFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceManyFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    loading={null}
+>
+    ...
+</ReferenceManyFieldBase>
+```
 
 ## `offline`
 

--- a/docs_headless/src/content/docs/ReferenceArrayFieldBase.md
+++ b/docs_headless/src/content/docs/ReferenceArrayFieldBase.md
@@ -87,11 +87,14 @@ You can change how the list of related records is rendered by passing a custom c
 | `reference`    | Required | `string`                                                                          | -                                | The name of the resource for the referenced records, e.g. 'tags'                                       |
 | `children`     | Optional\* | `Element`                                                                         |               | One or several elements that render a list of records based on a `ListContext`                         |
 | `render`     | Optional\* | `(ListContext) => Element`                                                                         |               | A function that takes a list context and renders a list of records                        |
+| `empty`        | Optional | `ReactNode`                                                                       | -                                | The component to render when the related records list is empty                                         |
+| `error`        | Optional | `ReactNode`                                                                       | -                                | The component to render when an error occurs while fetching the related records                        |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records (the filtering is done client-side)                   |
+| `loading`      | Optional | `ReactNode`                                                                       | -                                | The component to render while fetching the related records                                             |
 | `perPage`      | Optional | `number`                                                                          | 1000                             | Maximum number of results to display                                                                   |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v5/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                                                           |
 | `sort`         | Optional | `{ field, order }`                                                                | `{ field: 'id', order: 'DESC' }` | Sort order to use when displaying the related records (the sort is done client-side)                   |
-| `sortBy`       | Optional | `string | Function`                                                               | `source`                         | When used in a `List`, name of the field to use for sorting when the user clicks on the column header. |
+| `sortBy`       | Optional | `string \| Function`                                                               | `source`                         | When used in a `List`, name of the field to use for sorting when the user clicks on the column header. |
 
 \* Either one of children or render is required.
 
@@ -122,6 +125,70 @@ const TagList = (props: { children: React.ReactNode }) => {
         </p>
     );
 };
+```
+
+## `empty`
+
+By default, `<ReferenceArrayFieldBase>` renders its children when the related records list is empty. You can customize what is rendered by providing your own component via the `empty` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            empty={<p>No tags found.</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    empty={null}
+>
+    ...
+</ReferenceArrayFieldBase>
+```
+
+## `error`
+
+By default, `<ReferenceArrayFieldBase>` renders its children when an error occurs while fetching the related records. You can customize what is rendered by providing your own component via the `error` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            error={<p>Error loading tags. Please try again.</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    error={null}
+>
+    ...
+</ReferenceArrayFieldBase>
 ```
 
 ## `render`
@@ -167,6 +234,38 @@ For instance, to render only tags that are 'published', you can use the followin
     reference="tags"
     filter={{ is_published: true }}
 />
+```
+
+## `loading`
+
+By default, `<ReferenceArrayFieldBase>` renders its children while fetching the related records. You can customize what is rendered by providing your own component via the `loading` prop:
+
+```jsx
+import { ReferenceArrayFieldBase, ShowBase } from 'ra-core';
+
+export const PostShow = () => (
+    <ShowBase>
+        <ReferenceArrayFieldBase
+            source="tag_ids"
+            reference="tags"
+            loading={<p>Loading tags...</p>}
+        >
+            ...
+        </ReferenceArrayFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceArrayFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceArrayFieldBase
+    source="tag_ids"
+    reference="tags"
+    loading={null}
+>
+    ...
+</ReferenceArrayFieldBase>
 ```
 
 ## `perPage`

--- a/docs_headless/src/content/docs/ReferenceManyFieldBase.md
+++ b/docs_headless/src/content/docs/ReferenceManyFieldBase.md
@@ -86,11 +86,13 @@ export const PostList = () => (
 
 | Prop           | Required | Type                                                                              | Default                          | Description                                                                         |
 | -------------- | -------- | --------------------------------------------------------------------------------- | -------------------------------- | ----------------------------------------------------------------------------------- |
-| `children`     | Optional | `Element`                                                                         | -                                | One or several elements that render a list of records based on a `ListContext`      |
+| `children`     | Optional\* | `Element`                                                                         | -                                | One or several elements that render a list of records based on a `ListContext`      |
 | `render`     | Optional\* | `(ListContext) => Element`                                                                         | -                                | Function that receives a `ListContext` and returns an element      |
-| `debounce`     | Optional\* | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
+| `debounce`     | Optional | `number`                                                                          | 500                              | debounce time in ms for the `setFilters` callbacks                                  |
 | `empty`        | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records.                                |
+| `error`        | Optional | `ReactNode`                                                                       | -                                | The component to render when an error occurs while fetching the related records     |
 | `filter`       | Optional | `Object`                                                                          | -                                | Filters to use when fetching the related records, passed to `getManyReference()`    |
+| `loading`      | Optional | `ReactNode`                                                                       | -                                | The component to render while fetching the related records                          |
 | `offline`      | Optional | `ReactNode`                                                                       | -                                | Element to display when there are no related records because of lack of network connectivity. |
 | `perPage`      | Optional | `number`                                                                          | 25                               | Maximum number of referenced records to fetch                                       |
 | `queryOptions` | Optional | [`UseQuery Options`](https://tanstack.com/query/v3/docs/react/reference/useQuery) | `{}`                             | `react-query` options for the `getMany` query                                       |
@@ -167,6 +169,38 @@ Use `empty` to customize the text displayed when there are no related records.
 </ReferenceManyFieldBase>
 ```
 
+## `error`
+
+By default, `<ReferenceManyFieldBase>` renders its children when an error occurs while fetching the related records. You can customize what is rendered by providing your own component via the `error` prop:
+
+```jsx
+import { ReferenceManyFieldBase, ShowBase } from 'ra-core';
+
+export const AuthorShow = () => (
+    <ShowBase>
+        <ReferenceManyFieldBase
+            reference="books"
+            target="author_id"
+            error={<p>Error loading books. Please try again.</p>}
+        >
+            ...
+        </ReferenceManyFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceManyFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    error={null}
+>
+    ...
+</ReferenceManyFieldBase>
+```
+
 ## `filter`: Permanent Filter
 
 You can filter the query used to populate the possible values. Use the `filter` prop for that.
@@ -182,6 +216,38 @@ You can filter the query used to populate the possible values. Use the `filter` 
 </ReferenceManyFieldBase>
 ```
 
+
+## `loading`
+
+By default, `<ReferenceManyFieldBase>` renders its children while fetching the related records. You can customize what is rendered by providing your own component via the `loading` prop:
+
+```jsx
+import { ReferenceManyFieldBase, ShowBase } from 'ra-core';
+
+export const AuthorShow = () => (
+    <ShowBase>
+        <ReferenceManyFieldBase
+            reference="books"
+            target="author_id"
+            loading={<p>Loading books...</p>}
+        >
+            ...
+        </ReferenceManyFieldBase>
+    </ShowBase>
+);
+```
+
+You can also have `<ReferenceManyFieldBase>` render nothing in that case by setting the prop to `null`:
+
+```jsx
+<ReferenceManyFieldBase
+    reference="books"
+    target="author_id"
+    loading={null}
+>
+    ...
+</ReferenceManyFieldBase>
+```
 
 ## `offline`
 


### PR DESCRIPTION
## Problem

Some props are missing from the `<ReferenceArrayFieldBase>` and `<ReferenceManyFieldBase>` documentation

## Solution

Document the props

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
