### PR TITLE
[Doc] Improve sidebar scrolling on headless docs

### DIFF
--- a/docs_headless/src/components/CustomSidebar.astro
+++ b/docs_headless/src/components/CustomSidebar.astro
@@ -14,10 +14,21 @@ const { sidebar } = Astro.locals.starlightRoute;
             "a[aria-current='page']"
         );
         if (currentItem) {
-            sidebarContainer.scrollTo({
-                top: currentItem.offsetTop - sidebarContainer.offsetTop,
-                behavior: 'smooth',
-            });
+            // Check if the current item is already visible in the sidebar viewport
+            const containerRect = sidebarContainer.getBoundingClientRect();
+            const itemRect = currentItem.getBoundingClientRect();
+
+            const isItemVisible =
+                itemRect.top >= containerRect.top &&
+                itemRect.bottom <= containerRect.bottom;
+
+            // Only scroll if the item is not already visible
+            if (!isItemVisible) {
+                sidebarContainer.scrollTo({
+                    top: currentItem.offsetTop - sidebarContainer.offsetTop,
+                    behavior: 'auto',
+                });
+            }
         }
     });
 </script>


### PR DESCRIPTION
## Problem

- Sidebar smooth scroll on first load is disturbing
- Sidebar scroll is happening even when the selected item is already into view

## Solution

- disable scroll animation
- only scroll if element is not already into view

## How To Test

`make doc-headless`

1. Access a page for the first time on a lower item (e.g. ListBase)
2. Navigate to another page using the sidebar menu
3. Navigate to another page using a link from within the doc content: e.g. navigate from `<Resource recordRepresentation>` to `<RecordRepresentation>`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
