### PR TITLE
[Doc] Change ra-core documentation styles

### DIFF
--- a/docs_headless/src/styles/global.css
+++ b/docs_headless/src/styles/global.css
@@ -4,6 +4,14 @@
 @import 'tailwindcss/theme.css' layer(theme);
 @import 'tailwindcss/utilities.css' layer(utilities);
 
+:root {
+    --sl-color-bg-nav: var(--sl-color-black);
+    --sl-color-bg: var(--sl-color-black);
+    --sl-color-bg-sidebar: var(--sl-color-black);
+    --sl-color-accent: #bd0249;
+    --sl-color-accent-high: #ff78ac;
+}
+
 img.icon {
     display: inline;
     box-shadow: none;


### PR DESCRIPTION
## Problem

The `ra-core` [documentation](https://marmelab.com/ra-core/) looks too similar to the `shadcn-admin-kit` [documentation](https://marmelab.com/shadcn-admin-kit/docs/install/).

## Solution

Customize the theme

## How To Test

- `make doc-headless`

## Screenshots

<img width="1668" height="1238" alt="image" src="https://github.com/user-attachments/assets/cbc363f1-eb4c-4452-9acf-6262d37458f0" />

<img width="1668" height="1238" alt="image" src="https://github.com/user-attachments/assets/9eff4c3d-0578-474d-8158-33e2a03a9a9b" />

