### PR TITLE
Fix `useDeleteController` should get the record from closest `RecordContext`

### DIFF
--- a/packages/ra-core/src/controller/button/useDeleteController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteController.spec.tsx
@@ -1,0 +1,55 @@
+import * as React from 'react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { Route, Routes } from 'react-router';
+import { testDataProvider } from '../../dataProvider/testDataProvider';
+import { CoreAdminContext } from '../../core/CoreAdminContext';
+import { TestMemoryRouter } from '../../routing/TestMemoryRouter';
+import { useDeleteController } from './useDeleteController';
+import { RecordContextProvider } from '../record';
+import { ResourceContextProvider } from '../..';
+
+describe('useDeleteController', () => {
+    it('should get the record and the resource from closest context providers', async () => {
+        const dataProvider = testDataProvider({
+            delete: jest.fn((ressource, params) => {
+                return Promise.resolve({ data: params?.previousData });
+            }),
+        });
+
+        const MockComponent = () => {
+            const { handleDelete } = useDeleteController({
+                mutationMode: 'pessimistic',
+            });
+            return <button onClick={handleDelete}>Delete</button>;
+        };
+
+        render(
+            <TestMemoryRouter>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Routes>
+                        <Route
+                            path="/"
+                            element={
+                                <ResourceContextProvider value="posts">
+                                    <RecordContextProvider value={{ id: 1 }}>
+                                        <MockComponent />
+                                    </RecordContextProvider>
+                                </ResourceContextProvider>
+                            }
+                        />
+                    </Routes>
+                </CoreAdminContext>
+            </TestMemoryRouter>
+        );
+
+        const button = await screen.findByText('Delete');
+        fireEvent.click(button);
+
+        await waitFor(() =>
+            expect(dataProvider.delete).toHaveBeenCalledWith('posts', {
+                id: 1,
+                previousData: { id: 1 },
+            })
+        );
+    });
+});

--- a/packages/ra-core/src/controller/button/useDeleteController.spec.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteController.spec.tsx
@@ -52,4 +52,49 @@ describe('useDeleteController', () => {
             })
         );
     });
+    it('should allow to override the record and the resource from closest context providers', async () => {
+        const dataProvider = testDataProvider({
+            delete: jest.fn((ressource, params) => {
+                return Promise.resolve({ data: params?.previousData });
+            }),
+        });
+
+        const MockComponent = () => {
+            const { handleDelete } = useDeleteController({
+                resource: 'comments',
+                record: { id: 2 },
+                mutationMode: 'pessimistic',
+            });
+            return <button onClick={handleDelete}>Delete</button>;
+        };
+
+        render(
+            <TestMemoryRouter>
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <Routes>
+                        <Route
+                            path="/"
+                            element={
+                                <ResourceContextProvider value="posts">
+                                    <RecordContextProvider value={{ id: 1 }}>
+                                        <MockComponent />
+                                    </RecordContextProvider>
+                                </ResourceContextProvider>
+                            }
+                        />
+                    </Routes>
+                </CoreAdminContext>
+            </TestMemoryRouter>
+        );
+
+        const button = await screen.findByText('Delete');
+        fireEvent.click(button);
+
+        await waitFor(() =>
+            expect(dataProvider.delete).toHaveBeenCalledWith('comments', {
+                id: 2,
+                previousData: { id: 2 },
+            })
+        );
+    });
 });

--- a/packages/ra-core/src/controller/button/useDeleteController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteController.tsx
@@ -1,13 +1,14 @@
 import { useCallback, useMemo } from 'react';
 import { UseMutationOptions } from '@tanstack/react-query';
 
-import { useDelete } from '../../dataProvider';
-import { useUnselect } from '../';
-import { useRedirect, RedirectionSideEffect } from '../../routing';
-import { useNotify } from '../../notification';
+import { useDelete } from '../../dataProvider/useDelete';
+import { useUnselect } from '../list/useUnselect';
+import { useRecordContext } from '../record/useRecordContext';
+import { useRedirect, RedirectionSideEffect } from '../../routing/useRedirect';
+import { useNotify } from '../../notification/useNotify';
 import { RaRecord, MutationMode, DeleteParams } from '../../types';
-import { useResourceContext } from '../../core';
-import { useTranslate } from '../../i18n';
+import { useResourceContext } from '../../core/useResourceContext';
+import { useTranslate } from '../../i18n/useTranslate';
 
 /**
  * Prepare a set of callbacks for a delete button
@@ -67,13 +68,13 @@ export const useDeleteController = <
     props: UseDeleteControllerParams<RecordType, ErrorType>
 ): UseDeleteControllerReturn => {
     const {
-        record,
         redirect: redirectTo = 'list',
         mutationMode,
         mutationOptions = {},
         successMessage,
     } = props;
     const { meta: mutationMeta, ...otherMutationOptions } = mutationOptions;
+    const record = useRecordContext(props);
     const resource = useResourceContext(props);
     const notify = useNotify();
     const unselect = useUnselect(resource);


### PR DESCRIPTION
## Problem

`useDeleteController` does not require a `record` option. However, if not passed, it will fail at runtime.

## Solution

Ensure `useDeleteController` gets the record from the closest `RecordContext` by default.
## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
