### PR TITLE
Fix update removing meta and pageInfo properties from getManyReference result

### DIFF
--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -552,6 +552,58 @@ describe('useUpdate', () => {
                 });
             });
         });
+        it('updates getManyReference query cache with pageInfo when dataProvider promise resolves', async () => {
+            const queryClient = new QueryClient();
+            queryClient.setQueryData(['foo', 'getManyReference'], {
+                data: [{ id: 1, bar: 'bar' }],
+                pageInfo: {
+                    hasPreviousPage: false,
+                    hasNextPage: true,
+                },
+            });
+            const dataProvider = {
+                update: jest.fn(() =>
+                    Promise.resolve({ data: { id: 1, bar: 'baz' } } as any)
+                ),
+            } as any;
+            let localUpdate;
+            const Dummy = () => {
+                const [update] = useUpdate();
+                localUpdate = update;
+                return <span />;
+            };
+            render(
+                <CoreAdminContext
+                    dataProvider={dataProvider}
+                    queryClient={queryClient}
+                >
+                    <Dummy />
+                </CoreAdminContext>
+            );
+            localUpdate('foo', {
+                id: 1,
+                data: { bar: 'baz' },
+                previousData: { id: 1, bar: 'bar' },
+            });
+            await waitFor(() => {
+                expect(dataProvider.update).toHaveBeenCalledWith('foo', {
+                    id: 1,
+                    data: { bar: 'baz' },
+                    previousData: { id: 1, bar: 'bar' },
+                });
+            });
+            await waitFor(() => {
+                expect(
+                    queryClient.getQueryData(['foo', 'getManyReference'])
+                ).toEqual({
+                    data: [{ id: 1, bar: 'baz' }],
+                    pageInfo: {
+                        hasPreviousPage: false,
+                        hasNextPage: true,
+                    },
+                });
+            });
+        });
         it('updates getInfiniteList query cache when dataProvider promise resolves', async () => {
             const queryClient = new QueryClient();
             queryClient.setQueryData(['foo', 'getInfiniteList'], {

--- a/packages/ra-core/src/dataProvider/useUpdate.ts
+++ b/packages/ra-core/src/dataProvider/useUpdate.ts
@@ -193,9 +193,7 @@ export const useUpdate = <RecordType extends RaRecord = any, ErrorType = Error>(
         queryClient.setQueriesData(
             { queryKey: [resource, 'getManyReference'] },
             (res: GetListResult) =>
-                res && res.data
-                    ? { data: updateColl(res.data), total: res.total }
-                    : res,
+                res && res.data ? { ...res, data: updateColl(res.data) } : res,
             { updatedAt }
         );
     };


### PR DESCRIPTION
## Problem

On a successful update, the getManyReference data update was only copying the data and total from the original response, losing other properties like `meta` and `pageInfo`.

## Solution

Copy the full response like it is done for the getList response.

## How To Test

Have a page that both uses a `ReferenceManyField` components and updates the same resource with `useUpdate`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
