### PR TITLE
Fix `useMutationWithMutationMode` in `optimistic` and `undoable` mode may pass invalid parameters to the mutation

### DIFF
--- a/packages/ra-core/src/dataProvider/useMutationWithMutationMode.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useMutationWithMutationMode.spec.tsx
@@ -122,6 +122,7 @@ describe('useMutationWithMutationMode', () => {
             );
             return (
                 <>
+                    <p>{data.value}</p>
                     <button onClick={() => setData({ value: 'value2' })}>
                         Update data
                     </button>
@@ -138,6 +139,8 @@ describe('useMutationWithMutationMode', () => {
         fireEvent.click(screen.getByText('Update'));
         // In case of undoable, clicking the _Update data_ button would trigger the mutation
         fireEvent.click(screen.getByText('Update data'));
+        await screen.findByText('value2');
+        fireEvent.click(screen.getByText('Update'));
         await waitFor(() => {
             expect(dataProvider.updateUserProfile).toHaveBeenCalledWith({
                 data: { value: 'value1' },
@@ -145,7 +148,6 @@ describe('useMutationWithMutationMode', () => {
         });
 
         // Ensure the next call uses the latest data
-        fireEvent.click(screen.getByText('Update'));
         await waitFor(() => {
             expect(dataProvider.updateUserProfile).toHaveBeenCalledWith({
                 data: { value: 'value2' },


### PR DESCRIPTION
## Problem

After #10857, when passing parameters at declaration time to a mutation hook in `optimistic` or `undoable` mode, those params may be modified by the side effects before the actual mutation is called.

For instance, if you pass the `selectedIds` from the `ListContext` to a `useUpdateMany` hook and use the `useUnselectAll` hook to reset the `selectedIds` in the `onSuccess` side effect, then the actual mutation will be called with an empty array of ids.

You can see the issue like this:
- https://stackblitz.com/github/marmelab/react-admin/tree/master/examples/simple
- select multiple rows and click the _Reset views_ button
- check the dataProvider call in the console and check the call to `updateMany`
- beside, the views are back to their initial values once the mutation is actually called

## Solution

Keep the params in an additional ref that is freezed once the `mutate` callback is called.

## How To Test

- `make run`
- http://localhost:8080/#/posts
- select multiple rows and click the _Reset views_ button
- check the dataProvider call in the console and ensure the correct ids were passed to `updateMany`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
