### PR TITLE
Doc(Breadcrumb): Update OSS documentation to add new Breadcrumb components

### DIFF
--- a/docs/Breadcrumb.md
+++ b/docs/Breadcrumb.md
@@ -627,7 +627,7 @@ const PostEdit = () => (
 );
 ```
 
-**Tip**: If your `<Edit>` component has a `meta` parameter but manually calls [`useDefineAppLocation`](#usedefineapplocation) and provides it with the record, you don't need to set the `meta` prop on the `<Breadcrumb.EditItem>` as it will read the record from the `AppLocationContext`:
+**Tip**: If your `<Edit>` component has a `meta` parameter but manually calls [`useDefineAppLocation`](./useDefineAppLocation.md) and provides it with the record, you don't need to set the `meta` prop on the `<Breadcrumb.EditItem>` as it will read the record from the `AppLocationContext`:
 
 ```tsx
 const MyBreadcrumb = () => (
@@ -681,7 +681,7 @@ const PostShow = () => (
 );
 ```
 
-**Tip**: If your `<Show>` component has a `meta` parameter but manually calls [`useDefineAppLocation`](#usedefineapplocation) and provides it with the record, you don't need to set the `meta` prop on the `<Breadcrumb.ShowItem>` as it will read the record from the `AppLocationContext`:
+**Tip**: If your `<Show>` component has a `meta` parameter but manually calls [`useDefineAppLocation`](./useDefineAppLocation.md) and provides it with the record, you don't need to set the `meta` prop on the `<Breadcrumb.ShowItem>` as it will read the record from the `AppLocationContext`:
 
 ```tsx
 const MyBreadcrumb = () => (


### PR DESCRIPTION
## Problem

Breadcrumb documentation lags behind Enterprise documentation.

## Solution

Backport Breadcrumb components documentation.

## How To Test

`make doc`, then go to http://localhost:4000/Breadcrumb.html

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).

<img width="1905" height="16384" alt="localhost_4000_Breadcrumb html" src="https://github.com/user-attachments/assets/39e7b2ed-7fc5-44f9-9d98-00937c7fc169" />
