### PR TITLE
[Doc] Update `useRedirect` JSDoc to add absolute URL example

### DIFF
--- a/packages/ra-core/src/routing/useRedirect.ts
+++ b/packages/ra-core/src/routing/useRedirect.ts
@@ -30,6 +30,8 @@ export type RedirectionSideEffect = CreatePathType | false | RedirectToFunction;
  * redirect(false);
  * // redirect to the result of a function
  * redirect((resource, id, data) => ...)
+ * // redirect to an absolute URL
+ * redirect('https://marmelab.com/react-admin');
  */
 export const useRedirect = () => {
     const navigate = useNavigate();


### PR DESCRIPTION
## Problem

It is not clear that this function can use an absolute and external URL.

## Solution

Added an example.

## How To Test

NA.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (NA -> doc)
- [x] The PR includes one or several **stories** (NA -> doc)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
