### PR TITLE
[TypeScript] Fix `useShowController` result type

### DIFF
--- a/packages/ra-core/src/controller/show/useShowController.ts
+++ b/packages/ra-core/src/controller/show/useShowController.ts
@@ -178,7 +178,7 @@ export interface ShowControllerBaseResult<RecordType extends RaRecord = any> {
     isLoading: boolean;
     isPaused?: boolean;
     isPlaceholderData?: boolean;
-    redirectOnError: RedirectionSideEffect;
+    redirectOnError?: RedirectionSideEffect;
     resource: string;
     record?: RecordType;
     refetch: UseGetOneHookValue<RecordType>['refetch'];


### PR DESCRIPTION
## Problem

https://github.com/marmelab/react-admin/pull/10880 introduced a minor regression in the TS type of `ShowControllerBaseResult`, which is used notably to build the type of the `ShowContext`.

```tsx
        <ShowContextProvider
            value={{
                // Initialize a show context provider using deleted record info.
                defaultTitle,
                resource: deletedRecord.resource,
                record: deletedRecord.data,
                error: null,
                isLoading: false,
                isPending: false,
                isFetching: false,
                refetch: () => undefined as any,
            }}
        >
            {children}
        </ShowContextProvider>
```

Is now failing because `redirectOnError` is missing.

## Solution

Make this field optional in the TS type to avoid a TS BC.

## How To Test

`make build`
Also, build the `ra-core-ee` EE package with the latest RA packages.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
