### PR TITLE
[Chore] Use ReactNode instead of ReactElement where applicable

### DIFF
--- a/docs/Datagrid.md
+++ b/docs/Datagrid.md
@@ -54,7 +54,11 @@ Both are [Enterprise Edition](https://react-admin-ee.marmelab.com) components.
 | `body`               | Optional | `ReactNode`                 | `<Datagrid Body>`     | The component used to render the body of the table.           |
 | `bulkActionButtons`  | Optional | `ReactNode`                 | `<BulkDelete Button>` | The component used to render the bulk action buttons.         |
 | `empty`              | Optional | `ReactNode`                 | `<Empty>`             | The component used to render the empty table.                 |
+<<<<<<< HEAD
 | `expand`             | Optional | `ReactNode`                 |                       | The component used to render the expand panel for each row.   |
+=======
+| `expand`             | Optional | `ReactElement`                 |                       | The component used to render the expand panel for each row.   |
+>>>>>>> b718465c2 (Chore: Use ReactNode instead of ReactElement where applicable)
 | `expandSingle`       | Optional | Boolean                 | `false`               | Whether to allow only one expanded row at a time.             |
 | `header`             | Optional | `ReactNode`                 | `<Datagrid Header>`   | The component used to render the table header.                |
 | `hover`              | Optional | Boolean                 | `true`                | Whether to highlight the row under the mouse.                 |


### PR DESCRIPTION
Depends on #10996

## Problem

A lot of RA components expect a `ReactElement` where a `ReactNode` could be used.

## Solution

Replace `ReactElement` with `ReactNode` where applicable.

## How To Test

N/A

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).