### PR TITLE
[Doc] Mention Soft Delete in Buttons documentation

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -114,12 +114,12 @@ Alternately, pass a `successMessage` prop:
 
 ### Access Control
 
-If your `authProvider` implements [Access Control](./Permissions.md#access-control), `<DeleteButton>` will only render if the user has the "delete" access to the related resource.
+If your `authProvider` implements [Access Control](./Permissions.md#access-control), `<BulkDeleteButton>` will only render if the user has the "delete" access to the related resource.
 
-`<DeleteButton>` will call `authProvider.canAccess()` using the following parameters:
+`<BulkDeleteButton>` will call `authProvider.canAccess()` using the following parameters:
 
 ```txt
-{ action: "delete", resource: [current resource], record: [current record] }
+{ action: "delete", resource: [current resource] }
 ```
 
 ### Soft Delete


### PR DESCRIPTION
## Problem

Users might not know about Soft Delete.

## Solution

Make it easier to discover the feature from the `<DeleteButton>` and `<BulkDeleteButton>` documentation

## How To Test

- `make docker-doc`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
