### PR TITLE
Fix: Shift+Click deselection range not working properly in Datagrid

### DIFF
--- a/cypress/e2e/list.cy.js
+++ b/cypress/e2e/list.cy.js
@@ -224,6 +224,64 @@ describe('List Page', () => {
                 .click({ shiftKey: true });
             cy.contains('6 items selected');
         });
+
+        it('should allow to deselect a range with shift key', () => {
+            cy.contains('1-10 of 13'); // wait for data
+            cy.get(ListPagePosts.elements.selectItem).eq(0).click();
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(4)
+                .click({ shiftKey: true });
+            cy.contains('5 items selected');
+            cy.get(ListPagePosts.elements.selectedItem).should(els =>
+                expect(els).to.have.length(5)
+            );
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(2)
+                .click({ shiftKey: true });
+            cy.contains('2 items selected');
+            cy.get(ListPagePosts.elements.selectedItem).should(els =>
+                expect(els).to.have.length(2)
+            );
+        });
+
+        it('should allow alternating shift-select and shift-deselect', () => {
+            cy.contains('1-10 of 13'); // wait for data
+            cy.get(ListPagePosts.elements.selectItem).eq(0).click();
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(3)
+                .click({ shiftKey: true });
+            cy.contains('4 items selected');
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(4)
+                .click({ shiftKey: true });
+            cy.contains('5 items selected');
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(2)
+                .click({ shiftKey: true });
+            cy.contains('2 items selected');
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(4)
+                .click({ shiftKey: true });
+            cy.contains('5 items selected');
+            cy.get(ListPagePosts.elements.selectedItem).should(els =>
+                expect(els).to.have.length(5)
+            );
+        });
+
+        it('should support shift-deselect after select all then manual deselect', () => {
+            cy.contains('1-10 of 13'); // wait for data
+            ListPagePosts.toggleSelectAll();
+            cy.contains('10 items selected');
+            cy.get(ListPagePosts.elements.selectItem).eq(1).click();
+            cy.contains('9 items selected');
+            cy.get(ListPagePosts.elements.selectItem)
+                .eq(3)
+                .click({ shiftKey: true });
+            cy.contains('7 items selected');
+            cy.get(ListPagePosts.elements.selectedItem).should(els =>
+                expect(els).to.have.length(7)
+            );
+        });
     });
 
     describe('rowClick', () => {

--- a/packages/ra-core/src/dataTable/DataTableBase.tsx
+++ b/packages/ra-core/src/dataTable/DataTableBase.tsx
@@ -1,20 +1,20 @@
+import difference from 'lodash/difference';
+import union from 'lodash/union';
 import * as React from 'react';
 import { useEffect, useMemo, useRef, type FC, type ReactNode } from 'react';
-import union from 'lodash/union';
-import difference from 'lodash/difference';
 
-import { OptionalResourceContextProvider, useResourceContext } from '../core';
-import { useEvent } from '../util';
 import { useListContextWithProps } from '../controller/list/useListContextWithProps';
 import { type ListControllerResult } from '../controller/list/useListController';
-import { type RowClickFunctionBase } from './types';
+import { OptionalResourceContextProvider, useResourceContext } from '../core';
 import { type Identifier, type RaRecord, type SortPayload } from '../types';
-import { DataTableConfigContext } from './DataTableConfigContext';
+import { useEvent } from '../util';
 import { DataTableCallbacksContext } from './DataTableCallbacksContext';
+import { DataTableConfigContext } from './DataTableConfigContext';
 import { DataTableDataContext } from './DataTableDataContext';
 import { DataTableSelectedIdsContext } from './DataTableSelectedIdsContext';
 import { DataTableSortContext } from './DataTableSortContext';
 import { DataTableStoreContext } from './DataTableStoreContext';
+import { type RowClickFunctionBase } from './types';
 
 export const DataTableBase = function DataTable<
     RecordType extends RaRecord = any,
@@ -76,8 +76,6 @@ export const DataTableBase = function DataTable<
             if (!data) return;
             const ids = data.map(record => record.id);
             const lastSelectedIndex = ids.indexOf(lastSelected.current);
-            // @ts-ignore FIXME useEvent prevents using event.currentTarget
-            lastSelected.current = event.target.checked ? id : null;
 
             if (event.shiftKey && lastSelectedIndex !== -1) {
                 const index = ids.indexOf(id);
@@ -86,10 +84,10 @@ export const DataTableBase = function DataTable<
                     Math.max(lastSelectedIndex, index) + 1
                 );
 
-                // @ts-ignore FIXME useEvent prevents using event.currentTarget
-                const newSelectedIds = event.target.checked
-                    ? union(selectedIds, idsBetweenSelections)
-                    : difference(selectedIds, idsBetweenSelections);
+                const isClickedItemSelected = selectedIds?.includes(id);
+                const newSelectedIds = isClickedItemSelected
+                    ? difference(selectedIds, idsBetweenSelections)
+                    : union(selectedIds, idsBetweenSelections);
 
                 onSelect?.(
                     isRowSelectable
@@ -103,6 +101,8 @@ export const DataTableBase = function DataTable<
             } else {
                 onToggleItem?.(id);
             }
+
+            lastSelected.current = id;
         }
     );
 

--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
@@ -1,16 +1,16 @@
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import {
     Basic,
     Columns,
     Empty,
-    StandaloneStatic,
-    StandaloneDynamic,
     Expand,
     ExpandSingle,
     IsRowExpandable,
     IsRowSelectable,
     NonPrimitiveData,
+    StandaloneDynamic,
+    StandaloneStatic,
 } from './DataTable.stories';
 
 describe('DataTable', () => {
@@ -244,6 +244,31 @@ describe('DataTable', () => {
             await screen.findByText('7 items selected');
             fireEvent.click(checkboxes[0]);
             await screen.findByText('2 items selected');
+        });
+        it('should support alternating shift-select and shift-deselect', async () => {
+            render(<Basic />);
+            const checkboxes = await screen.findAllByRole('checkbox');
+            fireEvent.click(checkboxes[1]);
+            fireEvent.click(checkboxes[4], { shiftKey: true });
+            await screen.findByText('4 items selected');
+            fireEvent.click(checkboxes[5], { shiftKey: true });
+            await screen.findByText('5 items selected');
+            fireEvent.click(checkboxes[3], { shiftKey: true });
+            await screen.findByText('2 items selected');
+            fireEvent.click(checkboxes[5], { shiftKey: true });
+            await screen.findByText('5 items selected');
+        });
+        it('should support shift-deselect after select all then deselect one', async () => {
+            render(<Basic />);
+            const checkboxes = await screen.findAllByRole('checkbox');
+            fireEvent.click(checkboxes[0]);
+            const selectAllButton = await screen.findByText('Select all');
+            selectAllButton.click();
+            await screen.findByText('7 items selected');
+            fireEvent.click(checkboxes[2]);
+            await screen.findByText('6 items selected');
+            fireEvent.click(checkboxes[4], { shiftKey: true });
+            await screen.findByText('4 items selected');
         });
     });
     describe('isRowSelectable', () => {


### PR DESCRIPTION
## Problem

While investigating [#11010](https://github.com/marmelab/react-admin/issues/11010), I discovered that the **Shift+Click deselection behavior** actually exists in the Datagrid, but was only **partially working** in some cases.

- Basic range selection worked fine  
- But in specific scenarios (e.g. after “Select All”, or when alternating select/deselect actions), Shift+Click didn’t correctly update the selection state.  

This led to UX inconsistencies compared to common list-selection patterns in tools like Gmail, Google Sheets, or file explorers.

---

## Solution

- Fixed the range toggle logic in `DataTableBase.tsx`:
  - Detects whether the clicked item is already selected (instead of relying on `event.target.checked`)
  - Always updates `lastSelected.current`, even when deselecting
  - Ensures consistent Shift+Select and Shift+Deselect behavior  

Added **unit tests** in `DataTable.spec.tsx`  
Added **E2E tests** in `list.cy.js`  

Both confirm correct behavior for:
- Alternating Shift+Select and Shift+Deselect  
- Shift+Deselect after “Select All”

---

## How To Test

1. Go to any list view with bulk selection enabled.  
2. Select a first item, then **Shift+Click** another to select a range.  
3. **Shift+Click** one of the selected items again → all items in that range should now be **deselected**.  
4. Run tests:
    - `make test`
    - `make e2e`  
   All DataTable and E2E tests should pass.

---

## Additional Checks

- [x] The PR targets `master` for a bugfix  
- [x] The PR includes **unit tests** (`DataTable.spec.tsx`)  
- [x] The PR includes **E2E tests** (`list.cy.js`)  
- [ ] No documentation change required (behavior aligns with existing feature)  
- [ ] No story update required (visual behavior unchanged)

---

## Notes

- Fixes partial inconsistencies mentioned in [#11010](https://github.com/marmelab/react-admin/issues/11010).  
- No breaking changes.  
- Improves UX consistency with standard multi-selection behavior.  
- A couple of unrelated tests occasionally fail on `master` (confirmed unrelated to this change).  

> I'm happy to adjust anything if needed 👍