### PR TITLE
[Doc] Document how to support line-breaks in notifications

### DIFF
--- a/docs/useNotify.md
+++ b/docs/useNotify.md
@@ -145,6 +145,15 @@ notify(
 );
 ```
 
+You also need to set the `multiLine` option to `true` when your message contains line breaks (`\n`):
+
+```jsx
+notify(
+    'Line 1\nLine 2\nLine 3',
+    { multiLine: true }
+);
+```
+
 ## `type`
 
 This option lets you choose the notification type. It can be `info`, `success`, `warning` or `error`. The default is `info`.

--- a/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.stories.tsx
@@ -81,6 +81,25 @@ export const Multiline = () => (
     </Wrapper>
 );
 
+const LineBreakNotification = () => {
+    const notify = useNotify();
+    React.useEffect(() => {
+        notify(
+            'Lorem ipsum dolor sit amet, consectetur adipiscing elit.\nSed euismod, nisl nec ultricies aliquam, nisl nisl aliquet nisl, eget aliquet nisl nisl eu nisl.\nSed euismod, nisl nec ultricies aliquam, nisl nisl aliquet nisl, eget aliquet nisl nisl eu nisl.',
+            {
+                multiLine: true,
+            }
+        );
+    }, [notify]);
+    return null;
+};
+
+export const LineBreak = () => (
+    <Wrapper>
+        <LineBreakNotification />
+    </Wrapper>
+);
+
 const AutoHideDurationNotification = () => {
     const notify = useNotify();
     React.useEffect(() => {


### PR DESCRIPTION
## Problem

The docs already tell about the `multiLine` prop, but it doesn't say this prop is required to render line-breaks.

## Solution

Add this case to the docs and to the storybook

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-layout-notification--line-break

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
