### PR TITLE
Revert "Fix optimistic query invalidation"

### DIFF
--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -26,12 +26,7 @@ import {
     WithMiddlewaresSuccess as WithMiddlewaresSuccessUndoable,
     WithMiddlewaresError as WithMiddlewaresErrorUndoable,
 } from './useCreate.undoable.stories';
-import {
-    Middleware,
-    MutationMode,
-    Params,
-    InvalidateList,
-} from './useCreate.stories';
+import { Middleware, MutationMode, Params } from './useCreate.stories';
 
 describe('useCreate', () => {
     it('returns a callback that can be used with create arguments', async () => {
@@ -631,16 +626,5 @@ describe('useCreate', () => {
             fireEvent.click(screen.getByText('Refresh'));
             await screen.findByText('Bazinga');
         });
-    });
-
-    it('invalidates getList query when dataProvider resolves in undoable mode', async () => {
-        render(<InvalidateList mutationMode="undoable" />);
-        fireEvent.change(await screen.findByLabelText('title'), {
-            target: { value: 'New Post' },
-        });
-        fireEvent.click(screen.getByText('Save'));
-        await screen.findByText('resources.posts.notifications.created');
-        fireEvent.click(screen.getByText('Close'));
-        await screen.findByText('3: New Post');
     });
 });

--- a/packages/ra-core/src/dataProvider/useCreate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.stories.tsx
@@ -1,6 +1,5 @@
 import * as React from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
-import fakeRestDataProvider from 'ra-data-fakerest';
 
 import { CoreAdmin, CoreAdminContext, Resource } from '../core';
 import { useCreate } from './useCreate';
@@ -383,71 +382,4 @@ const RefreshButton = () => {
             Refresh
         </button>
     );
-};
-
-export const InvalidateList = ({
-    mutationMode,
-}: {
-    mutationMode: MutationModeType;
-}) => {
-    const dataProvider = fakeRestDataProvider(
-        {
-            posts: [
-                { id: 1, title: 'Hello' },
-                { id: 2, title: 'World' },
-            ],
-        },
-        process.env.NODE_ENV !== 'test',
-        process.env.NODE_ENV === 'test' ? 10 : 1000
-    );
-
-    return (
-        <TestMemoryRouter initialEntries={['/posts/create']}>
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource
-                    name="posts"
-                    create={
-                        <CreateBase mutationMode={mutationMode}>
-                            <Form>
-                                {mutationMode !== 'pessimistic' && (
-                                    <TextInput source="id" defaultValue={3} />
-                                )}
-                                <TextInput source="title" />
-                                <button type="submit">Save</button>
-                            </Form>
-                        </CreateBase>
-                    }
-                    list={
-                        <ListBase loading={<p>Loading...</p>}>
-                            <RecordsIterator
-                                render={(record: any) => (
-                                    <div
-                                        style={{
-                                            display: 'flex',
-                                            gap: '8px',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        {record.id}: {record.title}
-                                    </div>
-                                )}
-                            />
-                            <Notification />
-                        </ListBase>
-                    }
-                />
-            </CoreAdmin>
-        </TestMemoryRouter>
-    );
-};
-InvalidateList.args = {
-    mutationMode: 'undoable',
-};
-InvalidateList.argTypes = {
-    mutationMode: {
-        control: {
-            type: 'select',
-        },
-        options: ['pessimistic', 'optimistic', 'undoable'],
-    },
 };

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -160,7 +160,7 @@ export const useCreate = <
 
                 return clonedData;
             },
-            getQueryKeys: ({ resource, ...params }, { mutationMode }) => {
+            getSnapshot: ({ resource, ...params }, { mutationMode }) => {
                 const queryKeys: any[] = [
                     [resource, 'getList'],
                     [resource, 'getInfiniteList'],
@@ -176,7 +176,27 @@ export const useCreate = <
                     ]);
                 }
 
-                return queryKeys;
+                /**
+                 * Snapshot the previous values via queryClient.getQueriesData()
+                 *
+                 * The snapshotData ref will contain an array of tuples [query key, associated data]
+                 *
+                 * @example
+                 * [
+                 *   [['posts', 'getOne', { id: '1' }], { id: 1, title: 'Hello' }],
+                 *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+                 *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+                 * ]
+                 *
+                 * @see https://react-query-v3.tanstack.com/reference/QueryClient#queryclientgetqueriesdata
+                 */
+                const snapshot = queryKeys.reduce(
+                    (prev, queryKey) =>
+                        prev.concat(queryClient.getQueriesData({ queryKey })),
+                    [] as Snapshot
+                );
+
+                return snapshot;
             },
             getMutateWithMiddlewares: mutationFn => {
                 if (getMutateWithMiddlewares) {

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -20,7 +20,7 @@ import {
     ErrorCase as ErrorCaseUndoable,
     SuccessCase as SuccessCaseUndoable,
 } from './useDelete.undoable.stories';
-import { MutationMode, Params, InvalidateList } from './useDelete.stories';
+import { MutationMode, Params } from './useDelete.stories';
 
 describe('useDelete', () => {
     it('returns a callback that can be used with deleteOne arguments', async () => {
@@ -730,17 +730,6 @@ describe('useDelete', () => {
                     ],
                     pageParams: [],
                 });
-            });
-        });
-
-        it('invalidates getList query when dataProvider resolves in undoable mode', async () => {
-            render(<InvalidateList mutationMode="undoable" />);
-            await screen.findByText('Title: Hello');
-            fireEvent.click(await screen.findByText('Delete'));
-            await screen.findByText('resources.posts.notifications.deleted');
-            fireEvent.click(screen.getByText('Close'));
-            await waitFor(() => {
-                expect(screen.queryByText('1: Hello')).toBeNull();
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/useDelete.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.stories.tsx
@@ -1,22 +1,11 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
-import fakeRestDataProvider from 'ra-data-fakerest';
 
-import { CoreAdmin, CoreAdminContext, Resource } from '../core';
+import { CoreAdminContext } from '../core';
 import { useDelete } from './useDelete';
 import { useGetList } from './useGetList';
 import type { DataProvider, MutationMode as MutationModeType } from '../types';
-import {
-    EditBase,
-    ListBase,
-    RecordsIterator,
-    useDeleteController,
-    WithRecord,
-} from '../controller';
-import { TestMemoryRouter } from '../routing';
-import { useNotificationContext } from '../notification';
-import { useTakeUndoableMutation } from './undo';
 
 export default { title: 'ra-core/dataProvider/useDelete' };
 
@@ -172,111 +161,4 @@ const ParamsCore = () => {
             {isMutating !== 0 && <div>mutating</div>}
         </>
     );
-};
-
-const Notification = () => {
-    const { notifications, resetNotifications } = useNotificationContext();
-    const takeMutation = useTakeUndoableMutation();
-
-    return notifications.length > 0 ? (
-        <>
-            <div>{notifications[0].message}</div>
-            <div style={{ display: 'flex', gap: '16px' }}>
-                <button
-                    onClick={() => {
-                        if (notifications[0].notificationOptions?.undoable) {
-                            const mutation = takeMutation();
-                            if (mutation) {
-                                mutation({ isUndo: false });
-                            }
-                        }
-                        resetNotifications();
-                    }}
-                >
-                    Close
-                </button>
-            </div>
-        </>
-    ) : null;
-};
-
-const DeleteButton = ({ mutationMode }: { mutationMode: MutationModeType }) => {
-    const { isPending, handleDelete } = useDeleteController({
-        mutationMode,
-        redirect: 'list',
-    });
-    return (
-        <button onClick={handleDelete} disabled={isPending}>
-            Delete
-        </button>
-    );
-};
-
-export const InvalidateList = ({
-    mutationMode,
-}: {
-    mutationMode: MutationModeType;
-}) => {
-    const dataProvider = fakeRestDataProvider(
-        {
-            posts: [
-                { id: 1, title: 'Hello' },
-                { id: 2, title: 'World' },
-            ],
-        },
-        process.env.NODE_ENV !== 'test',
-        process.env.NODE_ENV === 'test' ? 10 : 1000
-    );
-
-    return (
-        <TestMemoryRouter initialEntries={['/posts/1']}>
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource
-                    name="posts"
-                    edit={
-                        <EditBase>
-                            <div>
-                                <h1>Edit Post</h1>
-                                <WithRecord
-                                    render={record => (
-                                        <div>Title: {record.title}</div>
-                                    )}
-                                />
-                                <DeleteButton mutationMode={mutationMode} />
-                            </div>
-                        </EditBase>
-                    }
-                    list={
-                        <ListBase loading={<p>Loading...</p>}>
-                            <RecordsIterator
-                                render={(record: any) => (
-                                    <div
-                                        style={{
-                                            display: 'flex',
-                                            gap: '8px',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        {record.id}: {record.title}
-                                    </div>
-                                )}
-                            />
-                            <Notification />
-                        </ListBase>
-                    }
-                />
-            </CoreAdmin>
-        </TestMemoryRouter>
-    );
-};
-InvalidateList.args = {
-    mutationMode: 'undoable',
-};
-InvalidateList.argTypes = {
-    mutationMode: {
-        control: {
-            type: 'select',
-        },
-        options: ['pessimistic', 'optimistic', 'undoable'],
-    },
 };

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -211,14 +211,34 @@ export const useDelete = <
 
                 return params.previousData;
             },
-            getQueryKeys: ({ resource }) => {
+            getSnapshot: ({ resource }) => {
                 const queryKeys = [
                     [resource, 'getList'],
                     [resource, 'getInfiniteList'],
                     [resource, 'getMany'],
                     [resource, 'getManyReference'],
                 ];
-                return queryKeys;
+
+                /**
+                 * Snapshot the previous values via queryClient.getQueriesData()
+                 *
+                 * The snapshotData ref will contain an array of tuples [query key, associated data]
+                 *
+                 * @example
+                 * [
+                 *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+                 *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+                 * ]
+                 *
+                 * @see https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetqueriesdata
+                 */
+                const snapshot = queryKeys.reduce(
+                    (prev, queryKey) =>
+                        prev.concat(queryClient.getQueriesData({ queryKey })),
+                    [] as Snapshot
+                );
+
+                return snapshot;
             },
             onSettled: (
                 result,

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -6,7 +6,7 @@ import { QueryClient, useMutationState } from '@tanstack/react-query';
 import { CoreAdminContext } from '../core';
 import { testDataProvider } from './testDataProvider';
 import { useDeleteMany } from './useDeleteMany';
-import { MutationMode, Params, InvalidateList } from './useDeleteMany.stories';
+import { MutationMode, Params } from './useDeleteMany.stories';
 
 describe('useDeleteMany', () => {
     it('returns a callback that can be used with update arguments', async () => {
@@ -388,16 +388,6 @@ describe('useDeleteMany', () => {
                     ],
                     pageParams: [],
                 });
-            });
-        });
-
-        it('invalidates getList query when dataProvider resolves in undoable mode', async () => {
-            render(<InvalidateList mutationMode="undoable" />);
-            fireEvent.click(await screen.findByText('Delete'));
-            await screen.findByText('resources.posts.notifications.deleted');
-            fireEvent.click(screen.getByText('Close'));
-            await waitFor(() => {
-                expect(screen.queryByText('1: Hello')).toBeNull();
             });
         });
     });

--- a/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.stories.tsx
@@ -1,16 +1,11 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
-import fakeRestDataProvider from 'ra-data-fakerest';
 
-import { CoreAdmin, CoreAdminContext, Resource } from '../core';
+import { CoreAdminContext } from '../core';
 import { useDeleteMany } from './useDeleteMany';
 import { useGetList } from './useGetList';
 import type { DataProvider, MutationMode as MutationModeType } from '../types';
-import { TestMemoryRouter, useRedirect } from '../routing';
-import { useNotificationContext, useNotify } from '../notification';
-import { useTakeUndoableMutation } from './undo';
-import { EditBase, ListBase, RecordsIterator } from '../controller';
 
 export default { title: 'ra-core/dataProvider/useDeleteMany' };
 
@@ -87,125 +82,6 @@ const MutationModeCore = () => {
             {isMutating !== 0 && <div>mutating</div>}
         </>
     );
-};
-
-const Notification = () => {
-    const { notifications, resetNotifications } = useNotificationContext();
-    const takeMutation = useTakeUndoableMutation();
-
-    return notifications.length > 0 ? (
-        <>
-            <div>{notifications[0].message}</div>
-            <div style={{ display: 'flex', gap: '16px' }}>
-                <button
-                    onClick={() => {
-                        if (notifications[0].notificationOptions?.undoable) {
-                            const mutation = takeMutation();
-                            if (mutation) {
-                                mutation({ isUndo: false });
-                            }
-                        }
-                        resetNotifications();
-                    }}
-                >
-                    Close
-                </button>
-            </div>
-        </>
-    ) : null;
-};
-
-const DeleteButton = ({ mutationMode }: { mutationMode: MutationModeType }) => {
-    const notify = useNotify();
-    const redirect = useRedirect();
-    const [deleteMany, { isPending }] = useDeleteMany();
-    const handleClick = () => {
-        deleteMany(
-            'posts',
-            {
-                ids: [1],
-            },
-            {
-                mutationMode,
-                onSuccess: () => {
-                    notify('resources.posts.notifications.deleted', {
-                        type: 'info',
-                        undoable: mutationMode === 'undoable',
-                    });
-                    redirect('list', 'posts');
-                },
-            }
-        );
-    };
-    return (
-        <button onClick={handleClick} disabled={isPending}>
-            Delete
-        </button>
-    );
-};
-
-export const InvalidateList = ({
-    mutationMode,
-}: {
-    mutationMode: MutationModeType;
-}) => {
-    const dataProvider = fakeRestDataProvider(
-        {
-            posts: [
-                { id: 1, title: 'Hello' },
-                { id: 2, title: 'World' },
-            ],
-        },
-        process.env.NODE_ENV !== 'test',
-        process.env.NODE_ENV === 'test' ? 10 : 1000
-    );
-
-    return (
-        <TestMemoryRouter initialEntries={['/posts/1']}>
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource
-                    name="posts"
-                    edit={
-                        <EditBase>
-                            <div>
-                                <h1>Edit Post</h1>
-                                <DeleteButton mutationMode={mutationMode} />
-                            </div>
-                        </EditBase>
-                    }
-                    list={
-                        <ListBase loading={<p>Loading...</p>}>
-                            <RecordsIterator
-                                render={(record: any) => (
-                                    <div
-                                        style={{
-                                            display: 'flex',
-                                            gap: '8px',
-                                            alignItems: 'center',
-                                        }}
-                                    >
-                                        {record.id}: {record.title}
-                                    </div>
-                                )}
-                            />
-                            <Notification />
-                        </ListBase>
-                    }
-                />
-            </CoreAdmin>
-        </TestMemoryRouter>
-    );
-};
-InvalidateList.args = {
-    mutationMode: 'undoable',
-};
-InvalidateList.argTypes = {
-    mutationMode: {
-        control: {
-            type: 'select',
-        },
-        options: ['pessimistic', 'optimistic', 'undoable'],
-    },
 };
 
 export const Params = ({ dataProvider }: { dataProvider?: DataProvider }) => {

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -238,14 +238,33 @@ export const useDeleteMany = <
 
                 return params.ids;
             },
-            getQueryKeys: ({ resource }) => {
+            getSnapshot: ({ resource }) => {
                 const queryKeys = [
                     [resource, 'getList'],
                     [resource, 'getInfiniteList'],
                     [resource, 'getMany'],
                     [resource, 'getManyReference'],
                 ];
-                return queryKeys;
+
+                /**
+                 * Snapshot the previous values via queryClient.getQueriesData()
+                 *
+                 * The snapshotData ref will contain an array of tuples [query key, associated data]
+                 *
+                 * @example
+                 * [
+                 *   [['posts', 'getList'], { data: [{ id: 1, title: 'Hello' }], total: 1 }],
+                 *   [['posts', 'getMany'], [{ id: 1, title: 'Hello' }]],
+                 * ]
+                 *
+                 * @see https://tanstack.com/query/v5/docs/react/reference/QueryClient#queryclientgetqueriesdata
+                 */
+                const snapshot = queryKeys.reduce(
+                    (prev, queryKey) =>
+                        prev.concat(queryClient.getQueriesData({ queryKey })),
+                    [] as Snapshot
+                );
+                return snapshot;
             },
             onSettled: (
                 result,

--- a/packages/ra-core/src/dataProvider/useMutationWithMutationMode.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useMutationWithMutationMode.spec.tsx
@@ -43,7 +43,7 @@ describe('useMutationWithMutationMode', () => {
             updateCache: ({ data }) => {
                 return data;
             },
-            getQueryKeys: () => {
+            getSnapshot: () => {
                 return [];
             },
             ...options,

--- a/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.spec.tsx
@@ -31,12 +31,7 @@ import {
     WithMiddlewaresSuccess as WithMiddlewaresSuccessUndoable,
     WithMiddlewaresError as WithMiddlewaresErrorUndoable,
 } from './useUpdate.undoable.stories';
-import {
-    Middleware,
-    MutationMode,
-    Params,
-    InvalidateList,
-} from './useUpdate.stories';
+import { Middleware, MutationMode, Params } from './useUpdate.stories';
 
 describe('useUpdate', () => {
     describe('mutate', () => {
@@ -658,18 +653,6 @@ describe('useUpdate', () => {
                 });
             });
         });
-
-        it('invalidates getList query when dataProvider resolves in undoable mode', async () => {
-            render(<InvalidateList mutationMode="undoable" />);
-            fireEvent.change(await screen.findByDisplayValue('Hello'), {
-                target: { value: 'Hello changed' },
-            });
-            fireEvent.click(screen.getByText('Save'));
-            await screen.findByText('resources.posts.notifications.updated');
-            fireEvent.click(screen.getByText('Close'));
-            await screen.findByText(/Hello changed/);
-        });
-
         describe('pessimistic mutation mode', () => {
             it('updates getOne query cache when dataProvider promise resolves', async () => {
                 const queryClient = new QueryClient();

--- a/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdate.stories.tsx
@@ -1,7 +1,6 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { QueryClient, useIsMutating } from '@tanstack/react-query';
-import fakeRestDataProvider from 'ra-data-fakerest';
 
 import { CoreAdmin, CoreAdminContext, Resource } from '../core';
 import { useUpdate } from './useUpdate';
@@ -333,61 +332,4 @@ const TextInput = (props: InputProps) => {
             <input id={id} {...field} />
         </div>
     );
-};
-
-export const InvalidateList = ({
-    mutationMode = 'undoable',
-}: {
-    mutationMode?: MutationModeType;
-}) => {
-    const dataProvider = fakeRestDataProvider(
-        {
-            posts: [
-                { id: 1, title: 'Hello' },
-                { id: 2, title: 'World' },
-            ],
-        },
-        process.env.NODE_ENV !== 'test',
-        process.env.NODE_ENV === 'test' ? 10 : 1000
-    );
-    return (
-        <TestMemoryRouter initialEntries={['/posts/1']}>
-            <CoreAdmin dataProvider={dataProvider}>
-                <Resource
-                    name="posts"
-                    list={
-                        <ListBase loading={<p>Loading...</p>}>
-                            <RecordsIterator
-                                render={record => (
-                                    <div>
-                                        {record.id}: {record.title}
-                                    </div>
-                                )}
-                            />
-                            <Notification />
-                        </ListBase>
-                    }
-                    edit={
-                        <EditBase mutationMode={mutationMode}>
-                            <Form>
-                                <TextInput source="title" />
-                                <button type="submit">Save</button>
-                            </Form>
-                        </EditBase>
-                    }
-                />
-            </CoreAdmin>
-        </TestMemoryRouter>
-    );
-};
-InvalidateList.args = {
-    mutationMode: 'undoable',
-};
-InvalidateList.argTypes = {
-    mutationMode: {
-        control: {
-            type: 'select',
-        },
-        options: ['pessimistic', 'optimistic', 'undoable'],
-    },
 };

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -17,7 +17,6 @@ import {
     Params,
     UndefinedValues,
     WithMiddlewares,
-    InvalidateList,
 } from './useUpdateMany.stories';
 
 describe('useUpdateMany', () => {
@@ -525,14 +524,6 @@ describe('useUpdateMany', () => {
             await screen.findByText(
                 '[{"id":1,"title":"world"},{"id":2,"title":"world"}]'
             ); // and not [{"title":"world"},{"title":"world"}]
-        });
-
-        it('invalidates getList query dataProvider resolves in undoable mode', async () => {
-            render(<InvalidateList mutationMode="undoable" />);
-            fireEvent.click(await screen.findByText('Update'));
-            await screen.findByText('resources.posts.notifications.updated');
-            fireEvent.click(screen.getByText('Close'));
-            await screen.findByText('1: Hello updated');
         });
     });
 


### PR DESCRIPTION
Reverts marmelab/react-admin#11013

This actually leads to duplicated dataProvider calls. For instance:
- Open the simple example
- Edit a post and save
- You'll see 2 `getList` calls