### PR TITLE
[Doc] Update README to use React 18 createRoot API

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ yarn add react-admin
 ```jsx
 // in app.js
 import * as React from "react";
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import { Admin, Resource } from 'react-admin';
 import restProvider from 'ra-data-simple-rest';
 
 import { PostList, PostEdit, PostCreate, PostIcon } from './posts';
 
-ReactDOM.createRoot(document.getElementById('root')!).render(
+createRoot(document.getElementById('root')!).render(
     <Admin dataProvider={restProvider('http://localhost:3000')}>
         <Resource name="posts" list={PostList} edit={PostEdit} create={PostCreate} icon={PostIcon} />
     </Admin>


### PR DESCRIPTION
Replace deprecated ReactDOM.render with createRoot API from react-dom/client. This aligns the documentation with React 18 best practices and the actual implementation used in the examples.

## Problem

_Describe the problem this PR solves_

## Solution

_Describe the solution this PR implements_

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [ ] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
