### PR TITLE
[Doc] Fix data provider options in Create React Admin documentation

### DIFF
--- a/docs/CreateReactAdmin.md
+++ b/docs/CreateReactAdmin.md
@@ -51,7 +51,7 @@ npm create react-admin@latest your-admin-name -- --interactive
 The command accepts the following options:
 
 * `--interactive`: Enable the CLI interactive mode
-* `--data-provider`: Set the data provider to use ("data-fakerest", "data-simple-rest", "data-json-server", "supabase" or "none")
+* `--data-provider`: Set the data provider to use ("fakerest", "simple-rest", "json-server", "supabase" or "none")
 * `--auth-provider`: Set the auth provider to use ("local-auth-provider" or "none")
 * `--resource`: Add a resource that will be initialized with guessers (can be used multiple times). Set to "skip" to bypass the interactive resource step.
 * `--install`: Set the package manager to use for installing dependencies ("yarn", "npm", "bun" or "skip" to bypass the interactive install step)


### PR DESCRIPTION
## Problem

Data provider options in the [Options](https://marmelab.com/react-admin/CreateReactAdmin.html#options) section of the CRA doc are wrong, however they are correct in the [`--data-provider`](https://marmelab.com/react-admin/CreateReactAdmin.html#--data-provider) section.

## Solution

Fix the doc.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
