### PR TITLE
fix: replace direct hasOwnProperty calls with Object.prototype.hasOwnProperty.call in validateResponseFormat

### DIFF
--- a/packages/ra-core/src/dataProvider/validateResponseFormat.ts
+++ b/packages/ra-core/src/dataProvider/validateResponseFormat.ts
@@ -10,7 +10,7 @@ function validateResponseFormat(response, type, logger = console.error) {
         logger(`The dataProvider returned an empty response for '${type}'.`);
         throw new Error('ra.notification.data_provider_error');
     }
-    if (!response.hasOwnProperty('data')) {
+    if (!Object.prototype.hasOwnProperty.call(response, 'data')) {
         logger(
             `The response to '${type}' must be like { data: ... }, but the received response does not have a 'data' key. The dataProvider is probably wrong for '${type}'.`
         );
@@ -29,7 +29,7 @@ function validateResponseFormat(response, type, logger = console.error) {
         fetchActionsWithArrayOfIdentifiedRecordsResponse.includes(type) &&
         Array.isArray(response.data) &&
         response.data.length > 0 &&
-        !response.data[0].hasOwnProperty('id')
+        !Object.prototype.hasOwnProperty.call(response.data[0], 'id')
     ) {
         logger(
             `The response to '${type}' must be like { data : [{ id: 123, ...}, ...] }, but the received data items do not have an 'id' key. The dataProvider is probably wrong for '${type}'`
@@ -38,7 +38,7 @@ function validateResponseFormat(response, type, logger = console.error) {
     }
     if (
         fetchActionsWithRecordResponse.includes(type) &&
-        !response.data.hasOwnProperty('id')
+        !Object.prototype.hasOwnProperty.call(response.data, 'id')
     ) {
         logger(
             `The response to '${type}' must be like { data: { id: 123, ... } }, but the received data does not have an 'id' key. The dataProvider is probably wrong for '${type}'`
@@ -47,8 +47,8 @@ function validateResponseFormat(response, type, logger = console.error) {
     }
     if (
         fetchActionsWithTotalResponse.includes(type) &&
-        !response.hasOwnProperty('total') &&
-        !response.hasOwnProperty('pageInfo')
+        !Object.prototype.hasOwnProperty.call(response, 'total') &&
+        !Object.prototype.hasOwnProperty.call(response, 'pageInfo')
     ) {
         logger(
             `The response to '${type}' must be like { data: [...], total: 123 } or { data: [...], pageInfo: {...} }, but the received response has neither a 'total' nor a 'pageInfo' key. The dataProvider is probably wrong for '${type}'`


### PR DESCRIPTION
## Description
This PR fixes unsafe usage of `hasOwnProperty` in the `validateResponseFormat` function by replacing direct calls with `Object.prototype.hasOwnProperty.call()`.

## Problem
Calling `hasOwnProperty` directly on objects can fail if:
- The object has a `hasOwnProperty` property that shadows the method
- The object is created with `Object.create(null)` and doesn't inherit from Object.prototype
- The object comes from an untrusted source

## Changes
- Line 13: `response.hasOwnProperty('data')` → `Object.prototype.hasOwnProperty.call(response, 'data')`
- Line 32: `response.data[0].hasOwnProperty('id')` → `Object.prototype.hasOwnProperty.call(response.data[0], 'id')`
- Line 41: `response.data.hasOwnProperty('id')` → `Object.prototype.hasOwnProperty.call(response.data, 'id')`
- Lines 50-51: `response.hasOwnProperty('total')` and `response.hasOwnProperty('pageInfo')` → `Object.prototype.hasOwnProperty.call(response, 'total')` and `Object.prototype.hasOwnProperty.call(response, 'pageInfo')`

## Impact
This is a defensive programming improvement that prevents potential runtime errors when validating data provider responses.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Code quality improvement
