### PR TITLE
Revert "[TypeScript] Fix usage of `ReactElement` when it should be `ReactNode`"

### DIFF
--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -28,7 +28,7 @@ import {
  * @prop {string} label Button label. Defaults to 'ra.action.delete, translated.
  * @prop {boolean} disabled Disable the button.
  * @prop {string} variant Material UI variant for the button. Defaults to 'contained'.
- * @prop {ReactNode} icon Override the icon. Defaults to the Delete icon from Material UI.
+ * @prop {ReactElement} icon Override the icon. Defaults to the Delete icon from Material UI.
  *
  * @param {Props} inProps
  *

--- a/packages/ra-ui-materialui/src/detail/CreateView.tsx
+++ b/packages/ra-ui-materialui/src/detail/CreateView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ElementType, ReactNode } from 'react';
+import type { ElementType, ReactElement, ReactNode } from 'react';
 import {
     Card,
     type ComponentsOverrides,
@@ -55,8 +55,8 @@ export const CreateView = (props: CreateViewProps) => {
 
 export interface CreateViewProps
     extends Omit<React.HTMLAttributes<HTMLDivElement>, 'title'> {
-    actions?: ReactNode | false;
-    aside?: ReactNode;
+    actions?: ReactElement | false;
+    aside?: ReactElement;
     component?: ElementType;
     sx?: SxProps<Theme>;
     title?: ReactNode;

--- a/packages/ra-ui-materialui/src/detail/EditView.tsx
+++ b/packages/ra-ui-materialui/src/detail/EditView.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import type { ElementType, ReactNode } from 'react';
+import type { ReactElement, ElementType, ReactNode } from 'react';
 import {
     Card,
     CardContent,
@@ -104,7 +104,7 @@ export const EditView = (props: EditViewProps) => {
 
 export interface EditViewProps
     extends Omit<React.HTMLAttributes<HTMLDivElement>, 'id' | 'title'> {
-    actions?: ReactNode | false;
+    actions?: ReactElement | false;
     aside?: ReactNode;
     component?: ElementType;
     emptyWhileLoading?: boolean;

--- a/packages/ra-ui-materialui/src/detail/Show.tsx
+++ b/packages/ra-ui-materialui/src/detail/Show.tsx
@@ -47,7 +47,7 @@ import { Loading } from '../layout';
  * @typedef {(showContext: Object) => ReactNode} RenderProp
  * @param {ShowProps} inProps
  * @param {RenderProp} inProps.render A function rendering the page content, receive the show context as its argument.
- * @param {ReactNode|false} inProps.actions An element to display above the page content, or false to disable actions.
+ * @param {ReactElement|false} inProps.actions An element to display above the page content, or false to disable actions.
  * @param {string} inProps.className A className to apply to the page content.
  * @param {ElementType} inProps.component The component to use as root component (div by default).
  * @param {boolean} inProps.emptyWhileLoading Do not display the page content while loading the initial data.

--- a/packages/ra-ui-materialui/src/detail/Tab.tsx
+++ b/packages/ra-ui-materialui/src/detail/Tab.tsx
@@ -164,7 +164,7 @@ export interface TabProps extends Omit<MuiTabProps, 'children'> {
     className?: string;
     divider?: ReactNode;
     icon?: ReactElement;
-    label: string | ReactNode;
+    label: string | ReactElement;
     path?: string;
     record?: RaRecord;
     spacing?: ResponsiveStyleValue<number | string>;

--- a/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceOneField.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactElement, ReactNode } from 'react';
 import { UseQueryOptions } from '@tanstack/react-query';
 import { Typography } from '@mui/material';
 import {
@@ -106,7 +106,7 @@ export interface ReferenceOneFieldProps<
     /**
      * @deprecated Use the empty prop instead
      */
-    emptyText?: string | ReactNode;
+    emptyText?: string | ReactElement;
     empty?: ReactNode;
     offline?: ReactNode;
     queryOptions?: Omit<

--- a/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
+++ b/packages/ra-ui-materialui/src/field/TranslatableFields.tsx
@@ -4,7 +4,7 @@ import {
     styled,
     useThemeProps,
 } from '@mui/material/styles';
-import type { ReactNode } from 'react';
+import type { ReactElement, ReactNode } from 'react';
 import {
     TranslatableContextProvider,
     useTranslatable,
@@ -68,7 +68,7 @@ import { TranslatableFieldsTabContent } from './TranslatableFieldsTabContent';
  * @param props The component props
  * @param {string} props.defaultLocale The locale selected by default. Default to 'en'.
  * @param {string[]} props.locales An array of the possible locales in the form. For example [{ 'en', 'fr' }].
- * @param {ReactNode} props.selector The element responsible for selecting a locale. Defaults to Material UI tabs.
+ * @param {ReactElement} props.selector The element responsible for selecting a locale. Defaults to Material UI tabs.
  */
 export const TranslatableFields = (inProps: TranslatableFieldsProps) => {
     const props = useThemeProps({
@@ -123,7 +123,7 @@ export interface TranslatableFieldsProps extends UseTranslatableOptions {
     className?: string;
     record?: RaRecord;
     resource?: string;
-    selector?: ReactNode;
+    selector?: ReactElement;
     groupKey?: string;
 }
 

--- a/packages/ra-ui-materialui/src/form/SimpleForm.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleForm.tsx
@@ -39,10 +39,10 @@ import { Toolbar } from './Toolbar';
  * );
  *
  * @typedef {Object} Props the props you can use (other props are injected by Create or Edit)
- * @prop {ReactNode[]} children Input elements
+ * @prop {ReactElement[]} children Input elements
  * @prop {Object} defaultValues
  * @prop {Function} validate
- * @prop {ReactNode} toolbar The element displayed at the bottom of the form, containing the SaveButton
+ * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  *
  * @param {Props} props
  */

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -67,10 +67,10 @@ import { FormTab } from './FormTab';
  * );
  *
  * @typedef {Object} Props the props you can use (other props are injected by Create or Edit)
- * @prop {ReactNode[]} FormTab elements
+ * @prop {ReactElement[]} FormTab elements
  * @prop {Object} defaultValues
  * @prop {Function} validate
- * @prop {ReactNode} toolbar The element displayed at the bottom of the form, containing the SaveButton
+ * @prop {ReactElement} toolbar The element displayed at the bottom of the form, containing the SaveButton
  *
  * @param {Props} props
  */
@@ -126,7 +126,7 @@ export interface TabbedFormProps
     resource?: string;
     syncWithLocation?: boolean;
     tabs?: ReactElement;
-    toolbar?: ReactNode | false;
+    toolbar?: ReactElement | false;
     warnWhenUnsavedChanges?: boolean;
 }
 

--- a/packages/ra-ui-materialui/src/input/ReferenceError.tsx
+++ b/packages/ra-ui-materialui/src/input/ReferenceError.tsx
@@ -1,12 +1,12 @@
 import * as React from 'react';
-import { ReactNode } from 'react';
+import { ReactElement } from 'react';
 import TextField from '@mui/material/TextField';
 
 export const ReferenceError = ({
     label,
     error,
 }: {
-    label?: ReactNode;
+    label?: string | ReactElement | false;
     error: Error;
 }) => (
     <TextField

--- a/packages/ra-ui-materialui/src/input/SelectInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectInput.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import {
-    type ReactNode,
+    type ReactElement,
     useCallback,
     useEffect,
     type ChangeEvent,
@@ -415,7 +415,7 @@ export type SelectInputProps = Omit<CommonInputProps, 'source'> &
     ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &
     Omit<TextFieldProps, 'label' | 'helperText' | 'classes' | 'onChange'> & {
-        emptyText?: ReactNode;
+        emptyText?: string | ReactElement;
         emptyValue?: any;
         resettable?: boolean;
         // Source is optional as AutocompleteInput can be used inside a ReferenceInput that already defines the source

--- a/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
+++ b/packages/ra-ui-materialui/src/input/TranslatableInputs.tsx
@@ -6,7 +6,7 @@ import {
     styled,
 } from '@mui/material/styles';
 import { StackProps, useThemeProps } from '@mui/material';
-import type { ReactNode } from 'react';
+import { ReactElement, ReactNode } from 'react';
 import {
     TranslatableContextProvider,
     useTranslatable,
@@ -67,7 +67,7 @@ import { TranslatableInputsTabContent } from './TranslatableInputsTabContent';
  * @param props The component props
  * @param {string} props.defaultLocale The locale selected by default. Default to 'en'.
  * @param {string[]} props.locales An array of the possible locales. For example: `['en', 'fr'].
- * @param {ReactNode} props.selector The element responsible for selecting a locale. Defaults to Material UI tabs.
+ * @param {ReactElement} props.selector The element responsible for selecting a locale. Defaults to Material UI tabs.
  */
 export const TranslatableInputs = (inProps: TranslatableInputsProps) => {
     const props = useThemeProps({
@@ -115,7 +115,7 @@ export const TranslatableInputs = (inProps: TranslatableInputsProps) => {
 
 export interface TranslatableInputsProps extends UseTranslatableOptions {
     className?: string;
-    selector?: ReactNode;
+    selector?: ReactElement;
     children: ReactNode;
     fullWidth?: boolean;
     groupKey?: string;

--- a/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
+++ b/packages/ra-ui-materialui/src/layout/MenuItemLink.tsx
@@ -1,4 +1,10 @@
-import React, { forwardRef, useCallback, useRef, type ReactNode } from 'react';
+import React, {
+    forwardRef,
+    useCallback,
+    useRef,
+    type ReactElement,
+    type ReactNode,
+} from 'react';
 import {
     type ComponentsOverrides,
     styled,
@@ -187,7 +193,7 @@ export type MenuItemLinkProps = Omit<
     LinkProps & MenuItemProps<'li'>,
     'placeholder' | 'onPointerEnterCapture' | 'onPointerLeaveCapture'
 > & {
-    leftIcon?: ReactNode;
+    leftIcon?: ReactElement;
     primaryText?: ReactNode;
     /**
      * @deprecated

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -5,7 +5,7 @@ import {
     styled,
     useThemeProps,
 } from '@mui/material/styles';
-import { memo, type ReactNode } from 'react';
+import { memo, type ReactElement } from 'react';
 import {
     IconButton,
     ListItem,
@@ -262,9 +262,9 @@ const StyledListItem = styled(ListItem, {
 });
 
 export interface FilterListItemProps extends Omit<ListItemProps, 'value'> {
-    label: ReactNode;
+    label: string | ReactElement;
     value: any;
-    icon?: ReactNode;
+    icon?: ReactElement;
     toggleFilter?: (value: any, filters: any) => any;
     isSelected?: (value: any, filters: any) => boolean;
 }

--- a/packages/ra-ui-materialui/src/list/filter/RemoveSavedQueryIconButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/RemoveSavedQueryIconButton.tsx
@@ -1,12 +1,14 @@
 import * as React from 'react';
-import { useState } from 'react';
+import { ReactElement, useState } from 'react';
 import { IconButton, IconButtonProps } from '@mui/material';
 import RemoveIcon from '@mui/icons-material/RemoveCircleOutline';
 import { useTranslate } from 'ra-core';
 
 import { RemoveSavedQueryDialog } from './RemoveSavedQueryDialog';
 
-export const RemoveSavedQueryIconButton = (props: IconButtonProps) => {
+export const RemoveSavedQueryIconButton = (
+    props: IconButtonProps
+): ReactElement => {
     const [confirmationOpen, setConfirmationOpen] = useState(false);
     const handleConfirmationClose = (): void => {
         setConfirmationOpen(false);

--- a/packages/ra-ui-materialui/src/list/filter/SavedQueryFilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/SavedQueryFilterListItem.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { memo } from 'react';
+import { type ReactElement, memo } from 'react';
 import {
     IconButton,
     ListItem,
@@ -27,7 +27,7 @@ const arePropsEqual = (
     isEqual(prevProps.value, nextProps.value);
 
 export const SavedQueryFilterListItem = memo(
-    (inProps: SavedQueryFilterListItemProps) => {
+    (inProps: SavedQueryFilterListItemProps): ReactElement => {
         const props = useThemeProps({
             props: inProps,
             name: PREFIX,


### PR DESCRIPTION
Reverts marmelab/react-admin#11030 which was merged instead of #11027