### PR TITLE
[Doc] Explain how to set up Jest for RA 5.13

### DIFF
--- a/docs/UnitTesting.md
+++ b/docs/UnitTesting.md
@@ -224,3 +224,19 @@ describe('UserShow', () => {
     });
 });
 ```
+
+## Working with Jest
+
+**Tip:** In general, we recommend using [Vitest](https://vitest.dev/) for testing React-admin applications, as it is faster and more modern than Jest. In particular, it is compatible out of the box with ESM and TypeScript, whereas Jest requires additional and experimental configuration for that. If, however, you are already using Jest, here are some tips to make it work smoothly with React-admin.
+
+Starting with version [5.13.0](https://github.com/marmelab/react-admin/pull/10995), React-admin changed the way it exports its modules to be fully compatible with ESM.
+
+- If you are using Jest in CJS mode (default), you will need to add the following configuration to your `jest.config.js` file to make sure React-admin packages are properly transformed:
+
+  ```diff
+-transformIgnorePatterns: ['node_modules/(?!(@hookform|react-hotkeys-hook))']
++transformIgnorePatterns: ['node_modules/(?!(@hookform|react-hotkeys-hook|react-admin|ra-core|ra-ui-materialui|ra-input-rich-text|ra-i18n-polyglot|ra-data-fakerest|ra-language-english))']
+  ```
+
+- If you are using Jest in ESM mode, then the React-admin packages should work without any further configuration. You shouldn't need `transformIgnorePatterns` at all.
+

--- a/docs_headless/src/content/docs/UnitTesting.md
+++ b/docs_headless/src/content/docs/UnitTesting.md
@@ -222,3 +222,21 @@ describe('UserShow', () => {
     });
 });
 ```
+
+## Working with Jest
+
+:::tip
+In general, we recommend using [Vitest](https://vitest.dev/) for testing ra-core applications, as it is faster and more modern than Jest. In particular, it is compatible out of the box with ESM and TypeScript, whereas Jest requires additional and experimental configuration for that. If, however, you are already using Jest, here are some tips to make it work smoothly with ra-core.
+:::
+
+Starting with version [5.13.0](https://github.com/marmelab/react-admin/pull/10995), ra-core changed the way it exports its modules to be fully compatible with ESM.
+
+- If you are using Jest in CJS mode (default), you will need to add the following configuration to your `jest.config.js` file to make sure ra-core is properly transformed:
+
+  ```diff
+  -transformIgnorePatterns: ['node_modules/(?!(@hookform|react-hotkeys-hook))']
+  +transformIgnorePatterns: ['node_modules/(?!(@hookform|react-hotkeys-hook|ra-core|ra-i18n-polyglot|ra-data-fakerest|ra-language-english))']
+  ```
+
+- If you are using Jest in ESM mode, then the ra-core packages should work without any further configuration. You shouldn't need `transformIgnorePatterns` at all.
+


### PR DESCRIPTION
## Problem

Because of https://github.com/marmelab/react-admin/pull/10995 Jest requires some additional config to work with react-admin in CJS mode. We had to change the configuration of the Enteprise repository, and we figured we might as well document this configuration for everyone in the official docs.

## Solution

Document the Jest config in the official docs (both RA and Headless)

## How To Test

- `make docker-doc`
- `make doc-headless`

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
