### PR TITLE
[chore] Fix release script copies invalid node_modules subfolder

### DIFF
--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -104,6 +104,7 @@ if [ -d $RA_ENTERPRISE_PATH ]; then
         cp -r packages/* \$RA_ENTERPRISE_PATH/node_modules &&
         cd \$RA_ENTERPRISE_PATH &&
         rm -rf node_modules/react-admin/node_modules/@mui &&
+        rm -rf node_modules/react-admin/node_modules/ra-ui-materialui &&
         make build
     "
     retry_step "Run the EE tests" "


### PR DESCRIPTION
## Problem

Release script copies everything inside the package folders into EE node_modules. This causes an issue because it also copies a folder under `node_modules/react-admin/node_modules/ra-ui-materialui`, which causes a weird TS error when building `ra-rbac` about components not being portable.

## Solution

Also exclude this folder from the copy (it should not be there when installing the package from npm anyway)

## How To Test

Run step 3 of the release script, then attempt to build ra-rbac `make build-ra-rbac`.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
