### PR TITLE
Fix imports from directory

### DIFF
--- a/packages/ra-core/src/auth/CanAccess.spec.tsx
+++ b/packages/ra-core/src/auth/CanAccess.spec.tsx
@@ -8,7 +8,7 @@ import {
     NoAuthProvider,
     AccessDenied,
 } from './CanAccess.stories';
-import { AuthProvider } from '..';
+import { AuthProvider } from '../types';
 
 describe('<CanAccess>', () => {
     it('renders nothing while loading by default', async () => {

--- a/packages/ra-core/src/auth/WithPermissions.stories.tsx
+++ b/packages/ra-core/src/auth/WithPermissions.stories.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import { AuthProvider } from '../types';
 import { CoreAdminContext } from '../core';
-import { TestMemoryRouter, WithPermissions } from '..';
+import { TestMemoryRouter } from '../routing';
+import WithPermissions from './WithPermissions';
 
 export default {
     title: 'ra-core/auth/WithPermissions',

--- a/packages/ra-core/src/auth/useCanAccess.stories.tsx
+++ b/packages/ra-core/src/auth/useCanAccess.stories.tsx
@@ -3,7 +3,7 @@ import { AuthProvider } from '../types';
 import { CoreAdminContext } from '../core';
 import { useCanAccess, UseCanAccessResult } from './useCanAccess';
 import { QueryClient } from '@tanstack/react-query';
-import { TestMemoryRouter } from '..';
+import { TestMemoryRouter } from '../routing';
 import { Route, Routes } from 'react-router';
 
 export default {

--- a/packages/ra-core/src/auth/useLogin.stories.tsx
+++ b/packages/ra-core/src/auth/useLogin.stories.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import usePermissions from './usePermissions';
-import { CoreAdminContext, TestMemoryRouter, useLogin, useLogout } from '..';
+import { CoreAdminContext } from '../core';
+import { TestMemoryRouter } from '../routing';
+import { useLogin, useLogout } from '../auth';
 
 export default {
     title: 'ra-core/auth/useLogin',

--- a/packages/ra-core/src/auth/usePermissions.spec.tsx
+++ b/packages/ra-core/src/auth/usePermissions.spec.tsx
@@ -7,7 +7,7 @@ import {
     NoAuthProviderGetPermissions,
     WithAuthProviderAndGetPermissions,
 } from './usePermissions.stories';
-import { AuthProvider } from '..';
+import { AuthProvider } from '../types';
 
 describe('usePermissions', () => {
     it('should return a loading state on mount with an authProvider that supports permissions', async () => {

--- a/packages/ra-core/src/auth/usePermissions.stories.tsx
+++ b/packages/ra-core/src/auth/usePermissions.stories.tsx
@@ -1,7 +1,9 @@
 import * as React from 'react';
 import usePermissions, { UsePermissionsResult } from './usePermissions';
 import { QueryClient } from '@tanstack/react-query';
-import { AuthProvider, CoreAdminContext, TestMemoryRouter } from '..';
+import { AuthProvider } from '../types';
+import { CoreAdminContext } from '../core';
+import { TestMemoryRouter } from '../routing';
 
 export default {
     title: 'ra-core/auth/usePermissions',

--- a/packages/ra-core/src/auth/useRequireAccess.stories.tsx
+++ b/packages/ra-core/src/auth/useRequireAccess.stories.tsx
@@ -4,7 +4,7 @@ import { Location, Route, Routes } from 'react-router';
 import { AuthProvider } from '../types';
 import { CoreAdminContext } from '../core';
 import { useRequireAccess, UseRequireAccessResult } from './useRequireAccess';
-import { TestMemoryRouter } from '..';
+import { TestMemoryRouter } from '../routing';
 
 export default {
     title: 'ra-core/auth/useRequireAccess',

--- a/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.spec.tsx
+++ b/packages/ra-core/src/core/useConfigureAdminRouterFromChildren.spec.tsx
@@ -8,8 +8,7 @@ import { CoreAdminContext } from './CoreAdminContext';
 import { CoreAdminRoutes } from './CoreAdminRoutes';
 import { Resource } from './Resource';
 import { CustomRoutes } from './CustomRoutes';
-import { CoreLayoutProps } from '../types';
-import { AuthProvider, ResourceProps } from '..';
+import { AuthProvider, CoreLayoutProps, ResourceProps } from '../types';
 import { TestMemoryRouter } from '../routing';
 
 const ResourceDefinitionsTestComponent = () => {

--- a/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDataProvider.spec.tsx
@@ -5,7 +5,7 @@ import expect from 'expect';
 
 import { useDataProvider } from './useDataProvider';
 import { CoreAdminContext } from '../core';
-import { GetListResult } from '..';
+import { GetListResult } from '../types';
 
 import { Prefetching } from './useDataProvider.stories';
 

--- a/packages/ra-core/src/dataProvider/useGetRecordId.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetRecordId.spec.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { useGetRecordId } from './useGetRecordId';
 import { render, screen } from '@testing-library/react';
 import { Route, Routes } from 'react-router-dom';
-import { RecordContextProvider } from '..';
+import { RecordContextProvider } from '../controller';
 
 import { TestMemoryRouter } from '../routing';
 

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.spec.tsx
@@ -6,7 +6,7 @@ import { QueryClient } from '@tanstack/react-query';
 import { testDataProvider } from './testDataProvider';
 import { PaginationPayload, SortPayload } from '../types';
 import { useInfiniteGetList } from './useInfiniteGetList';
-import { CoreAdminContext } from '..';
+import { CoreAdminContext } from '../core';
 
 describe('useInfiniteGetList', () => {
     const UseInfiniteGetList = ({

--- a/packages/ra-core/src/dataProvider/useInfiniteGetList.stories.tsx
+++ b/packages/ra-core/src/dataProvider/useInfiniteGetList.stories.tsx
@@ -8,7 +8,7 @@ import {
     Button,
     Typography,
 } from '@mui/material';
-import { useInfiniteGetList } from '..';
+import { useInfiniteGetList } from './useInfiniteGetList';
 
 import { CoreAdminContext } from '../core';
 import { countries } from '../storybook/data';

--- a/packages/ra-core/src/form/useRecordFromLocation.spec.tsx
+++ b/packages/ra-core/src/form/useRecordFromLocation.spec.tsx
@@ -5,7 +5,8 @@ import {
     getRecordFromLocation,
     useRecordFromLocation,
 } from './useRecordFromLocation';
-import { TestMemoryRouter, UseRecordFromLocationOptions } from '..';
+import { TestMemoryRouter } from '../routing';
+import { UseRecordFromLocationOptions } from '../form';
 
 describe('useRecordFromLocation', () => {
     const UseGetRecordFromLocation = (props: UseRecordFromLocationOptions) => {

--- a/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
+++ b/packages/ra-core/src/i18n/useTranslateLabel.stories.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { useTranslateLabel } from './useTranslateLabel';
 import { TestTranslationProvider } from './TestTranslationProvider';
-import { SourceContextProvider } from '..';
+import { SourceContextProvider } from '../core';
 
 export default {
     title: 'ra-core/i18n/useTranslateLabel',

--- a/packages/ra-core/src/routing/useGetPathForRecord.spec.tsx
+++ b/packages/ra-core/src/routing/useGetPathForRecord.spec.tsx
@@ -9,7 +9,7 @@ import {
     NoAuthProvider,
     SlowLoading,
 } from './useGetPathForRecord.stories';
-import { AuthProvider } from '..';
+import { AuthProvider } from '../types';
 
 describe('useGetPathForRecord', () => {
     it('should return an edit path for a record when there is no authProvider', async () => {

--- a/packages/ra-ui-materialui/src/auth/AuthCallback.tsx
+++ b/packages/ra-ui-materialui/src/auth/AuthCallback.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import { useHandleAuthCallback } from 'ra-core';
-import { Loading } from '..';
+import { Loading } from '../layout/Loading';
 import { AuthError } from './AuthError';
 
 /**

--- a/packages/ra-ui-materialui/src/layout/Layout.stories.tsx
+++ b/packages/ra-ui-materialui/src/layout/Layout.stories.tsx
@@ -14,7 +14,7 @@ import { Resource } from 'ra-core';
 import * as React from 'react';
 
 import { AdminContext } from '../AdminContext';
-import { AdminUI } from '..';
+import { AdminUI } from '../AdminUI';
 import { Layout } from './Layout';
 
 export default {


### PR DESCRIPTION
## Problem

Now that React Admin correctly export its modules, it appears some tools have issues with some of our ESM files because they import things from directories which is not supported in ESM.

## Solution

Fix those imports.
**Note**: although not required for the fix, I also corrected some of those imports in test/stories files to avoid our own tools (Jest) to load too many unnecessary things.

## How To Test

- `make build`
- create a new react admin app using this command to get the tests setup:
`yarn create react-admin myadmin --data-provider ra-data-fakerest --auth-provider local-auth-provider --resource posts --resource comments --install npm`
- copy the built packages inside the app node_modules
```sh
# In react-admin root directory
cp ./packages/ra-core/dist ../myadmin/node_modules/ra-core
cp ./packages/ra-ui-materialui/dist ../myadmin/node_modules/ra-ui-materialui
```
- run the tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
