### PR TITLE
[Storybook] Fix `<ArrayInputBase>` story issue when adding back a removed item

### DIFF
--- a/packages/ra-core/src/test-ui/SimpleFormIterator.tsx
+++ b/packages/ra-core/src/test-ui/SimpleFormIterator.tsx
@@ -14,6 +14,8 @@ import { SimpleFormIteratorBase } from '../controller/input/SimpleFormIteratorBa
 import { SimpleFormIteratorItemBase } from '../controller/input/SimpleFormIteratorItemBase';
 
 import { Confirm } from './Confirm';
+import { useGetArrayInputNewItemDefaults } from '../controller';
+import { useEvent } from '../util';
 
 const DefaultAddItemButton = (
     props: React.DetailedHTMLProps<
@@ -206,9 +208,16 @@ export const SimpleFormIterator = (props: SimpleFormIteratorProps) => {
     }, [remove]);
 
     const records = useFieldValue({ source: finalSource });
+    const getArrayInputNewItemDefaults =
+        useGetArrayInputNewItemDefaults(fields);
+
+    const getItemDefaults = useEvent((item: any = undefined) => {
+        if (item != null) return item;
+        return getArrayInputNewItemDefaults(children);
+    });
 
     return fields ? (
-        <SimpleFormIteratorBase {...props}>
+        <SimpleFormIteratorBase getItemDefaults={getItemDefaults} {...props}>
             <div
                 className={[
                     className,


### PR DESCRIPTION
## Problem

When you remove an item from the `<ArrayInputBase>` and add another, the values from the previously added item are used.

## Solution

This is because RHF requires that you provide values for a new item. As we can't know what inputs users will add, we have to actually inspect the `SimpleFormIterator` children to get their default values and use them for the new item. Until we have a better option, we extracted a hook to help with that.

## How To Test

- in the [story](https://react-admin-storybook-m3a3uovuo-marmelab.vercel.app/?path=/story/ra-core-controller-input-arrayinputbase--basic)
- remove the last item
- click add
=> you should have a new empty item

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
