### PR TITLE
Fix `<SelectAllButton>` ignores the `storeKey`

### DIFF
--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -199,6 +199,8 @@ export const useListController = <
         resource,
         sort: { field: query.sort, order: query.order },
         filter: { ...query.filter, ...filter },
+        disableSyncWithStore: storeKey === false,
+        storeKey: storeKey === false ? undefined : storeKey,
     });
 
     return {

--- a/packages/ra-core/src/controller/list/useSelectAll.spec.tsx
+++ b/packages/ra-core/src/controller/list/useSelectAll.spec.tsx
@@ -6,6 +6,7 @@ import {
     defaultDataProvider,
     Limit,
     QueryOptions,
+    StoreKey,
 } from './useSelectAll.stories';
 
 describe('useSelectAll', () => {

--- a/packages/ra-core/src/controller/list/useSelectAll.tsx
+++ b/packages/ra-core/src/controller/list/useSelectAll.tsx
@@ -43,7 +43,7 @@ import type { FilterPayload, RaRecord, SortPayload } from '../../types';
 export const useSelectAll = (
     params: UseSelectAllParams
 ): UseSelectAllResult => {
-    const { sort, filter } = params;
+    const { sort, filter, storeKey, disableSyncWithStore } = params;
     const resource = useResourceContext(params);
     if (!resource) {
         throw new Error(
@@ -52,7 +52,11 @@ export const useSelectAll = (
     }
     const dataProvider = useDataProvider();
     const queryClient = useQueryClient();
-    const [, { select }] = useRecordSelection({ resource });
+    const [, { select }] = useRecordSelection({
+        resource,
+        storeKey,
+        disableSyncWithStore,
+    });
     const notify = useNotify();
 
     const handleSelectAll = useEvent(
@@ -117,6 +121,8 @@ export interface UseSelectAllParams {
     resource?: string;
     sort?: SortPayload;
     filter?: FilterPayload;
+    storeKey?: string;
+    disableSyncWithStore?: boolean;
 }
 
 export interface HandleSelectAllParams<RecordType extends RaRecord = any> {

--- a/packages/ra-ui-materialui/src/button/SelectAllButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/SelectAllButton.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { fireEvent, render, screen } from '@testing-library/react';
-import { Basic, Label, Limit } from './SelectAllButton.stories';
+import { Basic, Label, Limit, StoreKey } from './SelectAllButton.stories';
 
 describe('<SelectAllButton />', () => {
     it('should render a "Select All" button', async () => {
@@ -74,5 +74,14 @@ describe('<SelectAllButton />', () => {
                 })
             ).toBeNull();
         });
+    });
+
+    it('should select all items with a storeKey', async () => {
+        render(<StoreKey />);
+        await screen.findByText('War and Peace');
+        fireEvent.click(screen.getAllByRole('checkbox')[0]);
+        await screen.findByText('10 items selected');
+        fireEvent.click(screen.getByRole('button', { name: 'Select all' }));
+        await screen.findByText('17 items selected');
     });
 });

--- a/packages/ra-ui-materialui/src/button/SelectAllButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/SelectAllButton.stories.tsx
@@ -171,3 +171,33 @@ export const Limit = () => (
         <SelectAllButton label="Select all books (max 15)" limit={15} />
     </Wrapper>
 );
+
+export const StoreKey = () => (
+    <TestMemoryRouter initialEntries={['/books']}>
+        <AdminContext dataProvider={dataProvider} i18nProvider={i18nProvider}>
+            <AdminUI>
+                <Resource
+                    name="books"
+                    list={() => (
+                        <List storeKey="license_components.embedded">
+                            <DataTable
+                                bulkActionsToolbar={
+                                    <BulkActionsToolbar
+                                        selectAllButton={<SelectAllButton />}
+                                    >
+                                        <BulkDeleteButton />
+                                    </BulkActionsToolbar>
+                                }
+                            >
+                                <DataTable.Col source="id" />
+                                <DataTable.Col source="title" />
+                                <DataTable.Col source="author" />
+                                <DataTable.NumberCol source="reads" />
+                            </DataTable>
+                        </List>
+                    )}
+                />
+            </AdminUI>
+        </AdminContext>
+    </TestMemoryRouter>
+);


### PR DESCRIPTION
## Problem

Fix https://github.com/marmelab/react-admin/issues/11058

## Solution

Properly forward the `storeKey` from the `ListContext` to the `useSelectAll` hook.

## How To Test

Unit test + story

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
