### PR TITLE
Fix `<Datagrid>` does not show the correct number of selected items

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
@@ -1,5 +1,11 @@
 import * as React from 'react';
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import {
+    render,
+    screen,
+    fireEvent,
+    waitFor,
+    within,
+} from '@testing-library/react';
 import {
     CoreAdminContext,
     testDataProvider,
@@ -10,7 +16,12 @@ import {
 import { ThemeProvider, createTheme } from '@mui/material';
 
 import { Datagrid } from './Datagrid';
-import { AccessControl, FullApp, SelectAllButton } from './Datagrid.stories';
+import {
+    AccessControl,
+    FullApp,
+    SelectAllButton,
+    Standalone,
+} from './Datagrid.stories';
 
 const TitleField = () => {
     const record = useRecordContext();
@@ -346,5 +357,25 @@ describe('<Datagrid />', () => {
                 ).toHaveLength(7)
             );
         });
+    });
+    it('should correctly select items after initial item selection followed by whole page selection', async () => {
+        render(<Standalone />);
+        await waitFor(() =>
+            expect(screen.getAllByText('The Lord of the Rings').length).toEqual(
+                2
+            )
+        );
+        fireEvent.click(
+            await within(
+                (
+                    await screen.findAllByText('The Lord of the Rings')
+                )[1].closest('tr')
+            ).findByLabelText('Select this row')
+        );
+        await screen.findByText('1 item selected');
+        expect(screen.queryByText('Select all')).toBeNull();
+        fireEvent.click(await screen.findByLabelText('Select all'));
+        await screen.findByText('7 items selected');
+        expect(screen.queryByText('Select all')).toBeNull();
     });
 });

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.stories.tsx
@@ -439,7 +439,10 @@ const MyCustomListInteractive = () => {
 
 export const Standalone = () => (
     <ThemeProvider theme={theme}>
-        <CoreAdminContext dataProvider={dataProvider}>
+        <CoreAdminContext
+            dataProvider={dataProvider}
+            i18nProvider={polyglotI18nProvider(() => defaultMessages, 'en')}
+        >
             <h1>Static</h1>
             <MyCustomList />
             <h1>Dynamic (with useList)</h1>

--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridHeader.tsx
@@ -58,11 +58,11 @@ export const DatagridHeader = (props: DatagridHeaderProps) => {
                 event.target.checked
                     ? selectedIds.concat(
                           data
-                              .filter(record =>
-                                  !selectedIds.includes(record.id) &&
-                                  isRowSelectable
-                                      ? isRowSelectable(record)
-                                      : true
+                              .filter(
+                                  record =>
+                                      !selectedIds.includes(record.id) &&
+                                      (!isRowSelectable ||
+                                          isRowSelectable(record))
                               )
                               .map(record => record.id)
                       )


### PR DESCRIPTION
## Problem

`<Datagrid>` does not show the correct number of selected items when selecting single items first then using the _Select all_ checkbox.

Fixes #11064

## Solution

The condition check in `<DatagridHeader>` was wrong.

## How To Test

- In this PR [Story](https://react-admin-storybook-2luh160y9-marmelab.vercel.app/?path=/story/ra-ui-materialui-list-datagrid--standalone), select a row, then click the header checkbox to select all rows. You should see that 7 items are selected and the _Select all_ button shouldn't appear.
- In production [Story](https://react-admin-storybook-gtmsam0v2-marmelab.vercel.app/?path=/story/ra-ui-materialui-list-datagrid--standalone), do the same. While you won't see the number of selected items because i18n is not setup, note that the _Select all_ button appears. This is because it checks whether the number of selected items is strictly equal to the total number of items. This is a side effect of the bug fixed in this PR.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
