### PR TITLE
Fix `memoryStore` does not support nested-looking keys

### DIFF
--- a/packages/ra-core/src/store/memoryStore.spec.ts
+++ b/packages/ra-core/src/store/memoryStore.spec.ts
@@ -40,4 +40,31 @@ describe('memoryStore', () => {
             expect(store.getItem('foo')).toEqual(undefined);
         });
     });
+
+    describe('nested-looking keys', () => {
+        it('should store and retrieve values in keys that appear nested without overriding content', () => {
+            const store = memoryStore();
+            store.setItem('foo', 'parent value');
+            store.setItem('foo.bar', 'nested value');
+
+            expect(store.getItem('foo')).toEqual('parent value');
+            expect(store.getItem('foo.bar')).toEqual('nested value');
+        });
+
+        it('should handle initial storage with nested objects', () => {
+            const initialStorage = {
+                user: {
+                    name: 'John',
+                    settings: {
+                        theme: 'dark',
+                    },
+                },
+            };
+
+            const store = memoryStore(initialStorage);
+
+            expect(store.getItem('user.name')).toEqual('John');
+            expect(store.getItem('user.settings.theme')).toEqual('dark');
+        });
+    });
 });


### PR DESCRIPTION
## Problem

Fix #11061

## Solution

Properly support nested keys in `memoryStore` 

## How To Test

run unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
