### PR TITLE
[Doc] Fix Headless documentation duplicate navigation entries

### DIFF
--- a/docs_headless/astro.config.mjs
+++ b/docs_headless/astro.config.mjs
@@ -184,9 +184,6 @@ export default defineConfig({
                         'arrayinputbase',
                         'referenceinputbase',
                         'referencearrayinputbase',
-                        'referencemanyinputbase',
-                        'referencemanytomanyinputbase',
-                        'referenceoneinputbase',
                         'simpleformiteratorbase',
                         enterpriseEntry(
                             'referencemanyinputbase',


### PR DESCRIPTION
## Problem

The headless documentation has duplicate navigation entries

## Solution

Remove the duplicate navigation entries

## How To Test

- `make doc-headless`

<img width="386" height="476" alt="image" src="https://github.com/user-attachments/assets/6ca64e1c-1999-4d07-9222-22a5c4c961f9" />

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
