### PR TITLE
Fix regression in `memoryStore`

### DIFF
--- a/packages/ra-core/src/store/StoreContextProvider.tsx
+++ b/packages/ra-core/src/store/StoreContextProvider.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect } from 'react';
 import { StoreContext } from './StoreContext';
 import { Store } from './types';
 
@@ -7,46 +7,15 @@ export const StoreContextProvider = ({
     value: Store,
     children,
 }: StoreContextProviderProps) => {
-    const initialized = useRef(false);
-    const itemsToSetAfterInitialization = useRef<Record<string, any>>([]);
-
     useEffect(() => {
         Store.setup();
-        // Because children might call setItem before the store is initialized,
-        // we store those calls parameters and apply them once the store is ready
-        if (itemsToSetAfterInitialization.current.length > 0) {
-            const items = Object.values(itemsToSetAfterInitialization.current);
-            for (const [key, value] of items) {
-                Store.setItem(key, value);
-            }
-            itemsToSetAfterInitialization.current = {};
-        }
-        initialized.current = true;
         return () => {
             Store.teardown();
-            initialized.current = false;
         };
     }, [Store]);
 
-    const wrapper = useMemo<Store>(() => {
-        return {
-            ...Store,
-            setItem: (key, value) => {
-                // Because children might call setItem before the store is initialized,
-                // we store those calls parameters and apply them once the store is ready
-                if (!initialized.current) {
-                    itemsToSetAfterInitialization.current.push([key, value]);
-                    return;
-                }
-                Store.setItem(key, value);
-            },
-        };
-    }, [Store, initialized]);
-
     return (
-        <StoreContext.Provider value={wrapper}>
-            {children}
-        </StoreContext.Provider>
+        <StoreContext.Provider value={Store}>{children}</StoreContext.Provider>
     );
 };
 

--- a/packages/ra-core/src/store/memoryStore.spec.tsx
+++ b/packages/ra-core/src/store/memoryStore.spec.tsx
@@ -8,12 +8,14 @@ import { StoreContextProvider } from './StoreContextProvider';
 describe('memoryStore', () => {
     it('should allow to store and retrieve a value', () => {
         const store = memoryStore();
+        store.setup();
         store.setItem('foo', 'bar');
         expect(store.getItem('foo')).toEqual('bar');
     });
     describe('removeItem', () => {
         it('should remove an item', () => {
             const store = memoryStore();
+            store.setup();
             store.setItem('foo', 'bar');
             store.setItem('hello', 'world');
             store.removeItem('foo');
@@ -24,6 +26,7 @@ describe('memoryStore', () => {
     describe('removeItems', () => {
         it('should remove all items with the given prefix', () => {
             const store = memoryStore();
+            store.setup();
             store.setItem('foo', 'bar');
             store.setItem('foo2', 'bar2');
             store.setItem('foo3', 'bar3');
@@ -38,6 +41,7 @@ describe('memoryStore', () => {
     describe('reset', () => {
         it('should reset the store', () => {
             const store = memoryStore();
+            store.setup();
             store.setItem('foo', 'bar');
             store.reset();
             expect(store.getItem('foo')).toEqual(undefined);
@@ -47,6 +51,7 @@ describe('memoryStore', () => {
     describe('nested-looking keys', () => {
         it('should store and retrieve values in keys that appear nested without overriding content', () => {
             const store = memoryStore();
+            store.setup();
             store.setItem('foo', 'parent value');
             store.setItem('foo.bar', 'nested value');
 
@@ -65,6 +70,7 @@ describe('memoryStore', () => {
             };
 
             const store = memoryStore(initialStorage);
+            store.setup();
 
             expect(store.getItem('user')).toEqual({ name: 'John' });
             expect(store.getItem('user.settings')).toEqual({ theme: 'dark' });

--- a/packages/ra-core/src/store/useStore.spec.tsx
+++ b/packages/ra-core/src/store/useStore.spec.tsx
@@ -1,11 +1,5 @@
 import * as React from 'react';
-import {
-    render,
-    screen,
-    fireEvent,
-    waitFor,
-    renderHook,
-} from '@testing-library/react';
+import { render, screen, fireEvent, renderHook } from '@testing-library/react';
 
 import { useStore } from './useStore';
 import { StoreContextProvider } from './StoreContextProvider';
@@ -68,17 +62,9 @@ describe('useStore', () => {
         expect(unsubscribe).toHaveBeenCalled();
     });
 
-    it('should allow to set values', async () => {
-        const { result } = renderHook(() => useStore('foo.bar'));
-        await waitFor(() => {
-            result.current[1]('hello');
-            expect(result.current[0]).toBe('hello');
-        });
-    });
-
     it('should update all components using the same store key on update', () => {
         const UpdateStore = () => {
-            const [, setValue] = useStore('foo.bar');
+            const [, setValue] = useStore<string>('foo.bar');
             return <button onClick={() => setValue('world')}>update</button>;
         };
         render(
@@ -92,9 +78,9 @@ describe('useStore', () => {
         screen.getByText('world');
     });
 
-    it('should not update components using other store key on update', () => {
+    it('should not update components using other store key on update', async () => {
         const UpdateStore = () => {
-            const [, setValue] = useStore('other.key');
+            const [, setValue] = useStore<string>('other.key');
             return <button onClick={() => setValue('world')}>update</button>;
         };
         render(
@@ -109,22 +95,28 @@ describe('useStore', () => {
     });
 
     it('should accept an updater function as parameter', async () => {
-        const { result } = renderHook(() => useStore('foo.bar'));
-        result.current[1]('hello');
-        let innerValue;
-        result.current[1](value => {
-            innerValue = value;
-            return 'world';
-        });
-        await waitFor(() => {
-            expect(innerValue).toBe('hello');
-        });
-        expect(result.current[0]).toBe('world');
+        const UpdateStore = () => {
+            const [, setValue] = useStore<string>('foo.bar');
+            return (
+                <button onClick={() => setValue(current => `${current} world`)}>
+                    update
+                </button>
+            );
+        };
+        render(
+            <StoreContextProvider value={memoryStore({ 'foo.bar': 'hello' })}>
+                <StoreReader name="foo.bar" />
+                <UpdateStore />
+            </StoreContextProvider>
+        );
+        screen.getByText('hello');
+        fireEvent.click(screen.getByText('update'));
+        screen.getByText('hello world');
     });
 
     it('should clear its value when the key changes', () => {
         const StoreConsumer = ({ storeKey }: { storeKey: string }) => {
-            const [value, setValue] = useStore(storeKey);
+            const [value, setValue] = useStore<string>(storeKey);
             return (
                 <>
                     <p>{value}</p>

--- a/packages/ra-ui-materialui/src/form/SimpleFormConfigurable.stories.tsx
+++ b/packages/ra-ui-materialui/src/form/SimpleFormConfigurable.stories.tsx
@@ -4,6 +4,8 @@ import {
     I18nContextProvider,
     TestMemoryRouter,
     ResourceContextProvider,
+    StoreContextProvider,
+    memoryStore,
 } from 'ra-core';
 import { ThemeProvider, createTheme, Box, Paper } from '@mui/material';
 import { QueryClientProvider, QueryClient } from '@tanstack/react-query';
@@ -29,13 +31,15 @@ const Wrapper = ({ children }) => (
         <ThemeProvider theme={createTheme(defaultTheme)}>
             <PreferencesEditorContextProvider>
                 <TestMemoryRouter>
-                    <ResourceContextProvider value="posts">
-                        <Inspector />
-                        <Box display="flex" justifyContent="flex-end">
-                            <InspectorButton />
-                        </Box>
-                        <Paper sx={{ width: 600, m: 2 }}>{children}</Paper>
-                    </ResourceContextProvider>
+                    <StoreContextProvider value={memoryStore()}>
+                        <ResourceContextProvider value="posts">
+                            <Inspector />
+                            <Box display="flex" justifyContent="flex-end">
+                                <InspectorButton />
+                            </Box>
+                            <Paper sx={{ width: 600, m: 2 }}>{children}</Paper>
+                        </ResourceContextProvider>
+                    </StoreContextProvider>
                 </TestMemoryRouter>
             </PreferencesEditorContextProvider>
         </ThemeProvider>

--- a/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/SelectColumnsButton.stories.tsx
@@ -1,5 +1,10 @@
 import * as React from 'react';
-import { PreferencesEditorContextProvider, TestMemoryRouter } from 'ra-core';
+import {
+    memoryStore,
+    PreferencesEditorContextProvider,
+    StoreContextProvider,
+    TestMemoryRouter,
+} from 'ra-core';
 import { Box } from '@mui/material';
 import { createTheme, ThemeProvider } from '@mui/material/styles';
 
@@ -44,22 +49,27 @@ export const Basic = () => (
         <PreferencesEditorContextProvider>
             <QueryClientProvider client={new QueryClient()}>
                 <TestMemoryRouter>
-                    <Box p={2}>
-                        <Box textAlign="right">
-                            <SelectColumnsButton resource="books" />
+                    <StoreContextProvider value={memoryStore()}>
+                        <Box p={2}>
+                            <Box textAlign="right">
+                                <SelectColumnsButton resource="books" />
+                            </Box>
+                            <DatagridConfigurable
+                                resource="books"
+                                data={data}
+                                sort={{ field: 'title', order: 'ASC' }}
+                                bulkActionButtons={false}
+                            >
+                                <TextField source="id" />
+                                <TextField
+                                    source="title"
+                                    label="Original title"
+                                />
+                                <TextField source="author" />
+                                <TextField source="year" />
+                            </DatagridConfigurable>
                         </Box>
-                        <DatagridConfigurable
-                            resource="books"
-                            data={data}
-                            sort={{ field: 'title', order: 'ASC' }}
-                            bulkActionButtons={false}
-                        >
-                            <TextField source="id" />
-                            <TextField source="title" label="Original title" />
-                            <TextField source="author" />
-                            <TextField source="year" />
-                        </DatagridConfigurable>
-                    </Box>
+                    </StoreContextProvider>
                 </TestMemoryRouter>
             </QueryClientProvider>
         </PreferencesEditorContextProvider>
@@ -71,23 +81,28 @@ export const WithPreferenceKey = () => (
         <PreferencesEditorContextProvider>
             <QueryClientProvider client={new QueryClient()}>
                 <TestMemoryRouter>
-                    <Box p={2}>
-                        <Box textAlign="right">
-                            <SelectColumnsButton preferenceKey="just-a-key.to_test_with" />
+                    <StoreContextProvider value={memoryStore()}>
+                        <Box p={2}>
+                            <Box textAlign="right">
+                                <SelectColumnsButton preferenceKey="just-a-key.to_test_with" />
+                            </Box>
+                            <DatagridConfigurable
+                                resource="books"
+                                preferenceKey="just-a-key.to_test_with"
+                                data={data}
+                                sort={{ field: 'title', order: 'ASC' }}
+                                bulkActionButtons={false}
+                            >
+                                <TextField source="id" />
+                                <TextField
+                                    source="title"
+                                    label="Original title"
+                                />
+                                <TextField source="author" />
+                                <TextField source="year" />
+                            </DatagridConfigurable>
                         </Box>
-                        <DatagridConfigurable
-                            resource="books"
-                            preferenceKey="just-a-key.to_test_with"
-                            data={data}
-                            sort={{ field: 'title', order: 'ASC' }}
-                            bulkActionButtons={false}
-                        >
-                            <TextField source="id" />
-                            <TextField source="title" label="Original title" />
-                            <TextField source="author" />
-                            <TextField source="year" />
-                        </DatagridConfigurable>
-                    </Box>
+                    </StoreContextProvider>
                 </TestMemoryRouter>
             </QueryClientProvider>
         </PreferencesEditorContextProvider>


### PR DESCRIPTION
## Problem

1. #11070 introduced a regression: You cannot pass an initial value that has a value containing an object anymore as it will be flattened
2. It looses its initial value in `React.StrictMode`

## Solution

1. Revert initial value setup so that it behaves like localStorage
Each property of the initial value is considered a key. For properties that shares a  common prefix, you should specify the key as `'prefix.key'`:
```js
const initialStorage = {
    user: {
        name: 'John',
    },
    'user.settings': {
        theme: 'dark',
    },
};
```

2. Ensure the setup function initializes the store correctly

## How To Test

- Unit tests

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
