### PR TITLE
fix(BulkDeleteWithConfirmButton): prevent mutationOptions from being passed to DOM

### DIFF
--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -43,13 +43,13 @@ export const BulkDeleteWithConfirmButton = (
         mutationMode,
         ...rest,
         mutationOptions: {
-            ...rest.mutationOptions,
+            ...mutationOptions,
             onSettled(...args) {
                 // In pessimistic mode, we wait for the mutation to be completed (either successfully or with an error) before closing
                 if (mutationMode === 'pessimistic') {
                     setOpen(false);
                 }
-                rest.mutationOptions?.onSettled?.(...args);
+                mutationOptions?.onSettled?.(...args);
             },
         },
     });


### PR DESCRIPTION
Should fix: #11076

## Problem

When using `BulkDeleteButton` with `mutationOptions`, React throws a warning:

> React does not recognize the `mutationOptions` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `mutationoptions` instead. If you accidentally passed it from a parent component, remove it from the DOM element.

This happens because `sanitizeRestProps` in `BulkDeleteWithConfirmButton` doesn't filter out `mutationOptions`, causing it to be passed through to the `StyledButton` and eventually to the DOM.

## Solution

Add `mutationOptions` to the destructured props in `sanitizeRestProps` so it gets filtered out before being spread onto the Button component.

## How To Test

1. Use `BulkDeleteButton` with `mutationOptions`:
```tsx
<BulkDeleteButton
  resource="posts"
  mutationOptions={{}}
/>
```
2. Open browser console
3. Before fix: React warning about mutationOptions prop on DOM element
4. After fix: No warning

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
