### PR TITLE
Fix `useAugmentedForm` resets the form one too many time

### DIFF
--- a/packages/ra-core/src/form/useAugmentedForm.ts
+++ b/packages/ra-core/src/form/useAugmentedForm.ts
@@ -88,7 +88,7 @@ export const useAugmentedForm = <RecordType = any>(
 
     useEffect(() => {
         reset(defaultValuesIncludingRecord);
-    }, [defaultValuesIncludingRecord, reset, isReady]);
+    }, [defaultValuesIncludingRecord, reset]);
 
     // notify on invalid form
     useNotifyIsFormInvalid(form.control, !disableInvalidFormNotification);


### PR DESCRIPTION
## Problem

https://github.com/marmelab/react-admin/pull/11071 fixed an issue affecting resetting form values for some Enterprise components, but the fix was incomplete as it left an unnecessary effect dependency which resulted in resetting the form one too many time.

## Solution

Clear the unnecessary effect dependency.

## How To Test

Unit tests + unit tests in Enterprise Edition workspace.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
