### PR TITLE
[Doc] Add deleteMany method to README and source code docs for json-server Data Provider

### DIFF
--- a/packages/ra-data-json-server/README.md
+++ b/packages/ra-data-json-server/README.md
@@ -14,16 +14,17 @@ npm install --save ra-data-json-server
 
 This Data Provider fits REST APIs powered by [JSON Server](https://github.com/typicode/json-server), such as [JSONPlaceholder](https://jsonplaceholder.typicode.com/).
 
-| Method             | API calls                                                                                               |
-| ------------------ | ------------------------------------------------------------------------------------------------------- |
-| `getList`          | `GET http://my.api.url/posts?_sort=title&_order=ASC&_start=0&_end=24&title=bar`                         |
-| `getOne`           | `GET http://my.api.url/posts/123`                                                                       |
-| `getMany`          | `GET http://my.api.url/posts?id=123&id=456&id=789`     |
-| `getManyReference` | `GET http://my.api.url/posts?author_id=345`                                                             |
-| `create`           | `POST http://my.api.url/posts`                                                                      |
-| `update`           | `PUT http://my.api.url/posts/123`                                                                       |
-| `updateMany`       | `PUT http://my.api.url/posts/123`, `PUT http://my.api.url/posts/456`, `PUT http://my.api.url/posts/789` |
-| `delete`           | `DELETE http://my.api.url/posts/123`                                                                    |
+| Method             | API calls                                                                                                        |
+| ------------------ | ---------------------------------------------------------------------------------------------------------------- |
+| `getList`          | `GET http://my.api.url/posts?_sort=title&_order=ASC&_start=0&_end=24&title=bar`                                  |
+| `getOne`           | `GET http://my.api.url/posts/123`                                                                                |
+| `getMany`          | `GET http://my.api.url/posts?id=123&id=456&id=789`                                                               |
+| `getManyReference` | `GET http://my.api.url/posts?author_id=345`                                                                      |
+| `create`           | `POST http://my.api.url/posts`                                                                                   |
+| `update`           | `PUT http://my.api.url/posts/123`                                                                                |
+| `updateMany`       | `PUT http://my.api.url/posts/123`, `PUT http://my.api.url/posts/456`, `PUT http://my.api.url/posts/789`          |
+| `delete`           | `DELETE http://my.api.url/posts/123`                                                                             |
+| `deleteMany`       | `DELETE http://my.api.url/posts/123`, `DELETE http://my.api.url/posts/456`, `DELETE http://my.api.url/posts/789` |
 
 **Note**: The JSON Server REST Data Provider expects the API to include a `X-Total-Count` header in the response to `getList` and `getManyReference` calls. The value must be the total number of resources in the collection. This allows react-admin to know how many pages of resources there are in total, and build the pagination controls.
 

--- a/packages/ra-data-json-server/src/index.ts
+++ b/packages/ra-data-json-server/src/index.ts
@@ -16,6 +16,7 @@ import { fetchUtils, DataProvider } from 'ra-core';
  * update           => PUT http://my.api.url/posts/123
  * updateMany       => PUT http://my.api.url/posts/123, PUT http://my.api.url/posts/456, PUT http://my.api.url/posts/789
  * delete           => DELETE http://my.api.url/posts/123
+ * deleteMany       => DELETE http://my.api.url/posts/123, DELETE http://my.api.url/posts/456, DELETE http://my.api.url/posts/789
  *
  * @example
  *


### PR DESCRIPTION
- add missing deleteMany usages in packages/ra-data-json-server/src/index.ts and packages/ra-data-json-server/README.md.
- reformat requests table in packages/ra-data-json-server/README.md

## Problem

Missing explanations in ra-data-json-server about deleteMany

## Solution

Add missing lines in form of others.

## How To Test

no need.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why): just a doc update
- [ ] The PR includes one or several **stories** (if not possible, describe why): just a doc update
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
