### PR TITLE
List: show empty page when only permanent filters are applied

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.tsx
+++ b/packages/ra-ui-materialui/src/list/List.tsx
@@ -104,7 +104,11 @@ export const List = <RecordType extends RaRecord = any>(
             // Disable offline support from ListBase as it is handled by ListView to keep the ListView container
             offline={false}
         >
-            <ListView<RecordType> {...rest} render={render} />
+            <ListView<RecordType>
+                {...rest}
+                render={render}
+                permanentFilter={filter}
+            />
         </ListBase>
     );
 };

--- a/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/ListNoResults.spec.tsx
@@ -1,6 +1,8 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { NoFilter, WithFilter } from './ListNoResults.stories';
+import { ListContextProvider } from 'ra-core';
+import { ListView } from './ListView';
 
 describe('ListNoResults', () => {
     it('should display no results found message when no filter', async () => {
@@ -13,5 +15,29 @@ describe('ListNoResults', () => {
         await screen.findByText('No results found with the current filters.');
         screen.getByText('Clear filters').click();
         await screen.findByText('{"id":1}');
+    });
+    it('renders Empty when list is empty with only permanent filters', () => {
+        render(
+            <ListContextProvider
+                value={{
+                    data: [],
+                    total: 0,
+                    filterValues: { is_published: true },
+                    isPending: false,
+                    hasPreviousPage: false,
+                    hasNextPage: false,
+                    resource: 'posts',
+                }}
+            >
+                <ListView
+                    permanentFilter={{ is_published: true }}
+                    empty={<div>No posts found</div>}
+                >
+                    <div />
+                </ListView>
+            </ListContextProvider>
+        );
+
+        screen.getByText('No posts found');
     });
 });

--- a/packages/ra-ui-materialui/src/list/ListView.tsx
+++ b/packages/ra-ui-materialui/src/list/ListView.tsx
@@ -39,6 +39,7 @@ export const ListView = <RecordType extends RaRecord = any>(
         title,
         empty = defaultEmpty,
         render,
+        permanentFilter = {},
         offline = defaultOffline,
         error,
         ...rest
@@ -72,6 +73,13 @@ export const ListView = <RecordType extends RaRecord = any>(
     ) {
         return null;
     }
+
+    const permanentKeys = Object.keys(permanentFilter);
+    const userFilterKeys = Object.keys(filterValues).filter(
+        key => !permanentKeys.includes(key)
+    );
+
+    const hasUserFilters = userFilterKeys.length > 0;
 
     const renderList = () => (
         <div
@@ -115,7 +123,7 @@ export const ListView = <RecordType extends RaRecord = any>(
                 // @ts-ignore FIXME total may be undefined when using partial pagination but the ListControllerResult type is wrong about it
                 data.length === 0)) &&
         // the user didn't set any filters
-        !Object.keys(filterValues).length &&
+        !hasUserFilters &&
         // there is an empty page component
         empty !== false;
 
@@ -425,6 +433,13 @@ export interface ListViewProps<RecordType extends RaRecord = any> {
      * );
      */
     sx?: SxProps<Theme>;
+
+    /**
+     * Permanent filters applied to the list.
+     * These filters are not set by the user and should not prevent the empty
+     * page from being displayed when the list has no results.
+     */
+    permanentFilter?: Record<string, any>;
 }
 
 const PREFIX = 'RaList';


### PR DESCRIPTION
## Problem

When a `List` is rendered with a permanent filter via the `filter` prop and the query returns no records, the `empty` component is not displayed.  
This happens because permanent filters are currently treated the same as user applied filters when deciding whether to render the empty page, even though permanent filters are not a user decision.

As a result, users are not prompted to create a record within the fixed scope defined by the permanent filter.

## Solution

Forward the permanent `filter` prop from `List` to `ListView` and use it to distinguish permanent filters from user-applied filters when computing the empty state.

The empty page is now rendered when:
- the list has no results, and
- no user applied filters are active

Permanent filters no longer prevent the empty page from being displayed, while user applied filters continue to behave as before.

## How To Test

1. Render a `List` with a permanent filter using the `filter` prop and an `empty` component.
2. Ensure the data provider returns no records for that filter.
3. Verify that the empty page is displayed.
4. Apply a user filter via the filter inputs.
5. Verify that the empty page is no longer displayed.

A unit test has been added to cover this scenario.

## Additional Checks

- [x] The PR targets `next` for a feature
- [x] The PR includes **unit tests**
- [ ] The PR includes one or several **stories** (not applicable)
- [ ] The **documentation** is up to date (not required for this behavior change)

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
