### PR TITLE
[Doc] Fix Inputs doc code example

### DIFF
--- a/docs/Inputs.md
+++ b/docs/Inputs.md
@@ -889,7 +889,7 @@ Now the component will render with a label:
 ```html
 <label>Position</label>
 <span>
-    <input name="lat" type="number" placeholder="longitude" value={record.lat} />
+    <input name="lat" type="number" placeholder="latitude" value={record.lat} />
     <input name="lng" type="number" placeholder="longitude" value={record.lng} />
 </span>
 ```


### PR DESCRIPTION
'Longitude' used as placeholder in both places - one shuold be 'latitude'.

