### PR TITLE
feat:expose renderInput in AutoCompleteInput props

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -855,6 +855,12 @@ export interface AutocompleteInputProps<
     // Source is optional as AutocompleteInput can be used inside a ReferenceInput that already defines the source
     source?: string;
     TextFieldProps?: TextFieldProps;
+    renderInput?: AutocompleteProps<
+        OptionType,
+        Multiple,
+        DisableClearable,
+        SupportCreate
+    >['renderInput'];
 }
 
 /**


### PR DESCRIPTION
## Problem

`AutocompleteInput` supports the `renderInput` prop at runtime via the underlying MUI Autocomplete component, but this prop is not exposed in the TypeScript definition of `AutocompleteInputProps`
As a result, TypeScript users cannot pass `renderInput` without losing type safety or relying on implicit typing.

Closes https://github.com/marmelab/react-admin/issues/10430

## Solution

This PR exposes the renderInput prop in the `AutocompleteInput` TypeScript interface by reusing the corresponding type from MUI’s `AutocompleteProps`
There is no runtime behavior change this only aligns the TypeScript definition with the existing supported API.

## How To Test

1. Use `AutocompleteInput` with a `renderInput` prop in a TypeScript project.

2. Verify that TypeScript does not report any type errors.

3. Run the test suite (`yarn test`) to ensure no regressions are introduced.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** ((not applicable typeScript only change with no runtime behavior)
- [ ] The PR includes one or several **stories** (not applicable no UI or behavioral change)
- [ ] The **documentation** is up to date(not required  this prop was already supported at runtime)

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
