### PR TITLE
[TypeScript] Fix  `ref` type regression when wrapping react-admin Button components

### DIFF
--- a/packages/ra-ui-materialui/src/button/CloneButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CloneButton.tsx
@@ -79,7 +79,7 @@ interface Props {
     scrollToTop?: boolean;
 }
 
-export type CloneButtonProps = Props & ButtonProps<typeof LinkBase>;
+export type CloneButtonProps = Props & Omit<ButtonProps<typeof LinkBase>, 'to'>;
 
 export default memo(CloneButton);
 

--- a/packages/ra-ui-materialui/src/button/EditButton.tsx
+++ b/packages/ra-ui-materialui/src/button/EditButton.tsx
@@ -122,7 +122,7 @@ interface Props<RecordType extends RaRecord = any> {
 }
 
 export type EditButtonProps<RecordType extends RaRecord = any> =
-    Props<RecordType> & ButtonProps<typeof LinkBase>;
+    Props<RecordType> & Omit<ButtonProps<typeof LinkBase>, 'to'>;
 
 const PREFIX = 'RaEditButton';
 

--- a/packages/ra-ui-materialui/src/button/ListButton.tsx
+++ b/packages/ra-ui-materialui/src/button/ListButton.tsx
@@ -115,7 +115,7 @@ interface Props {
     scrollToTop?: boolean;
 }
 
-export type ListButtonProps = Props & ButtonProps<typeof LinkBase>;
+export type ListButtonProps = Props & Omit<ButtonProps<typeof LinkBase>, 'to'>;
 
 const PREFIX = 'RaListButton';
 


### PR DESCRIPTION
Fixes #11134

## How to Test

Create a small wrapper around EditButtonProps (like the one from issue #11134):

```tsx
import { EditButton, EditButtonProps } from 'react-admin';

type Props = Omit<EditButtonProps, 'label'> & {
  source: string;
  text?: string;
  label?: string;
};

export const EditButtonEx = ({ source, text, ...rest }: Props) => (
  <EditButton {...rest} label={text} />
);
```

EditButton renders a MUI Button with component={LinkBase} + forwardRef, so its props should be typed as ButtonProps`<typeof LinkBase>` (not the default button props). This aligns EditButton, CloneButton, and ListButton with the existing pattern used by ShowButton.


## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why)
- [ ] The **documentation** is up to date

