### PR TITLE
Fix the most specific matching route when using pathless routes

### DIFF
--- a/packages/ra-router-tanstack/src/tanStackRouterProvider.spec.tsx
+++ b/packages/ra-router-tanstack/src/tanStackRouterProvider.spec.tsx
@@ -27,6 +27,7 @@ import {
     NestedResourcesPrecedence,
     PathlessLayoutRoutesPriority,
     PathlessLayoutRoutesWithEmptyRoute,
+    PathlessLayoutRoutesWithIndexRoute,
 } from './tanStackRouterProvider.stories';
 import { tanStackRouterProvider } from './tanStackRouterProvider';
 
@@ -1517,6 +1518,22 @@ describe('tanStackRouterProvider', () => {
         });
 
         fireEvent.click(screen.getByText('Home (path="")'));
+
+        await waitFor(() => {
+            expect(screen.getByTestId('home-page')).toBeInTheDocument();
+        });
+    });
+
+    it('should match the index route as most specific within pathless layout routes', async () => {
+        window.location.hash = '#/posts';
+
+        render(<PathlessLayoutRoutesWithIndexRoute />);
+
+        await waitFor(() => {
+            expect(screen.getByTestId('posts-page')).toBeInTheDocument();
+        });
+
+        fireEvent.click(screen.getByText('Home (index)'));
 
         await waitFor(() => {
             expect(screen.getByTestId('home-page')).toBeInTheDocument();

--- a/packages/ra-router-tanstack/src/tanStackRouterProvider.stories.tsx
+++ b/packages/ra-router-tanstack/src/tanStackRouterProvider.stories.tsx
@@ -1668,3 +1668,81 @@ export const PathlessLayoutRoutesWithEmptyRoute = () => {
         </RouterProviderContext.Provider>
     );
 };
+
+export const PathlessLayoutRoutesWithIndexRoute = () => {
+    const { RouterWrapper } = tanStackRouterProvider;
+
+    return (
+        <RouterProviderContext.Provider value={tanStackRouterProvider}>
+            <RouterWrapper>
+                <Routes>
+                    <Route
+                        path="*"
+                        element={
+                            <div data-testid="catchall-page">
+                                Catch-all Page
+                            </div>
+                        }
+                    />
+                    <Route
+                        element={
+                            <div data-testid="layout-wrapper">
+                                <h2>Layout Wrapper</h2>
+                                <nav>
+                                    <LinkBase
+                                        to="/posts"
+                                        style={{ marginRight: 10 }}
+                                    >
+                                        Posts
+                                    </LinkBase>
+                                    <LinkBase to="/comments">Comments</LinkBase>
+                                </nav>
+                                <nav>
+                                    <LinkBase
+                                        to="/"
+                                        style={{ marginRight: 10 }}
+                                    >
+                                        Home (index)
+                                    </LinkBase>
+                                </nav>
+                                <div
+                                    style={{
+                                        border: '2px solid blue',
+                                        padding: 20,
+                                        marginTop: 10,
+                                    }}
+                                >
+                                    <RouterOutlet />
+                                </div>
+                            </div>
+                        }
+                    >
+                        <Route
+                            index
+                            element={
+                                <div data-testid="home-page">
+                                    Home Page (index)
+                                </div>
+                            }
+                        />
+                        <Route
+                            path="/posts"
+                            element={
+                                <div data-testid="posts-page">Posts Page</div>
+                            }
+                        />
+                        <Route
+                            path="/comments"
+                            element={
+                                <div data-testid="comments-page">
+                                    Comments Page
+                                </div>
+                            }
+                        />
+                    </Route>
+                </Routes>
+                <LocationDisplay />
+            </RouterWrapper>
+        </RouterProviderContext.Provider>
+    );
+};

--- a/packages/ra-router-tanstack/src/tanStackRouterProvider.tsx
+++ b/packages/ra-router-tanstack/src/tanStackRouterProvider.tsx
@@ -744,6 +744,7 @@ const Routes = ({ children, location: locationProp }: RouterRoutesProps) => {
                         childMatch &&
                         // If no best match yet, or the child route is more specific than the current best, use this one
                         (!bestMatch ||
+                            childMatch.route.index ||
                             (bestMatch.route.path !== undefined &&
                                 childMatch.route.path !== undefined &&
                                 isMoreSpecific(


### PR DESCRIPTION
## Problem

In #11102, @WiXSL pointed the following (https://github.com/marmelab/react-admin/pull/11102#discussion_r2716869207):

> Pathless layout routes short‑circuit the match loop on the first layout with matching children. This bypasses the later “more specific” logic and can make matching order‑dependent, potentially selecting a layout route even if a more specific sibling should win.

After more investigations, he was right. When a more specific route was defined after a catch-all route nested in a pathless route, the catch-all route was returned before the more specific route was even evaluated. In the following example, the catch-all route `/users/*` was matched when the pathname was `/users/jane_doe/block`.

```tsx
<Route element={<RouterOutlet />}>
    <Route
        path="/users/*"
        element={
            <div data-testid="users-page">
                Users View
            </div>
        }
    />
</Route>
<Route
    path="/users/:username/block"
    element={
        <div data-testid="block-user-page">
            Block a user
        </div>
    }
/>
```

## Solution

Extract the matching route finding algorithm in a function, and call it recursively with the children of the pathless route to always find the most specific route.

## How To Test

- [Story](https://react-admin-storybook-2narrvh64-marmelab.vercel.app/?path=/story/ra-routing-tanstack-tanstack-router-provider--pathless-layout-routes-priority)

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date
