### PR TITLE
Prevent dragging column below the Reset button

### DIFF
--- a/packages/ra-ui-materialui/src/list/datatable/ColumnsSelector.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/ColumnsSelector.tsx
@@ -111,22 +111,21 @@ export const ColumnsSelector = ({ children }: ColumnsSelectorProps) => {
                         </DataTableColumnFilterContext.Provider>
                     </DataTableColumnRankContext.Provider>
                 ))}
-                <Box
-                    component="li"
-                    className="columns-selector-actions"
-                    sx={{ textAlign: 'center', mt: 1 }}
-                >
-                    <Button
-                        onClick={() => {
-                            setColumnRanks(undefined);
-                            setHiddenColumns(defaultHiddenColumns);
-                        }}
-                        label={translate('ra.action.reset', {
-                            _: 'Reset',
-                        })}
-                    />
-                </Box>
             </MenuList>
+            <Box
+                className="columns-selector-actions"
+                sx={{ textAlign: 'center', mb: 1 }}
+            >
+                <Button
+                    onClick={() => {
+                        setColumnRanks(undefined);
+                        setHiddenColumns(defaultHiddenColumns);
+                    }}
+                    label={translate('ra.action.reset', {
+                        _: 'Reset',
+                    })}
+                />
+            </Box>
         </Box>,
         container
     );


### PR DESCRIPTION
## Problem

Columns are draggable below the reset button.

## Solution

Move the reset button out of the `MenuList`, as we did with the search input before.

## How To Test

- [Story](https://react-admin-storybook-pxnsl02d3-marmelab.vercel.app/?path=/story/ra-ui-materialui-list-columnsbutton--basic): try to move the columns below the reset button.

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date
