### PR TITLE
[Doc] Add Spring Boot (REST) data provider to `DataProviderList.md`

### DIFF
--- a/docs/DataProviderList.md
+++ b/docs/DataProviderList.md
@@ -72,7 +72,7 @@ If you can't find a Data Provider for your backend below, no worries! [Writing a
 * ![marmelab Logo](./img/backend-logos/marmelab.png "marmelab Logo")**[REST](https://en.wikipedia.org/wiki/Representational_state_transfer)**: [marmelab/ra-data-simple-rest](https://github.com/marmelab/react-admin/tree/master/packages/ra-data-simple-rest)
 * ![soul logo](./img/backend-logos/soul.png "Soul Logo")**[Soul](https://thevahidal.github.io/soul/)**/**[SQLite](https://www.sqlite.org/index.html)**: [DeepBlueCLtd/RA-Soul](https://github.com/DeepBlueCLtd/RA-Soul)
 * ![spring Logo](./img/backend-logos/spring.svg "spring Logo")**[Spring Boot](https://spring.io/projects/spring-boot)**: [vishpat/ra-data-springboot-rest](https://github.com/vishpat/ra-data-springboot-rest)
-* ![spring Logo](./img/backend-logos/spring.svg "spring Logo")**[Spring Boot (REST)](https://spring.io/projects/spring-boot)**: [femrek/ra-spring-data-provider](https://github.com/femrek/ra-spring-data-provider)
+* ![spring Logo](./img/backend-logos/spring.svg "spring Logo")**[Spring Boot (dataProvider + backend)](https://spring.io/projects/spring-boot)**: [femrek/ra-spring-data-provider](https://github.com/femrek/ra-spring-data-provider)
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v3/v4](https://strapi.io/)**: [nazirov91/ra-strapi-rest](https://github.com/nazirov91/ra-strapi-rest)
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v4](https://strapi.io/)**: [garridorafa/ra-strapi-v4-rest](https://github.com/garridorafa/ra-strapi-v4-rest)
 * ![strapi Logo](./img/backend-logos/strapi.png "strapi Logo")**[Strapi v5](https://strapi.io/)**: [marmelab/ra-strapi](https://github.com/marmelab/ra-strapi/tree/main/packages/ra-strapi)


### PR DESCRIPTION
## Problem

As I mentioned [this](https://github.com/marmelab/react-admin/issues/11120) issue, current data provider for Spring does not includes backend specifications. And I have developed a Frontend+Backend library to solve this end to end.

This pr adds my repo to data provider list page. This pr adds a new line under the existing Spring Boot line but you may think about replacing due to inactivity.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why): just a doc update
- [ ] The PR includes one or several **stories** (if not possible, describe why): just a doc update
- [x] The **documentation** is up to date
