### PR TITLE
Add support for random delay in ra-data-fakerest

### DIFF
--- a/packages/ra-data-fakerest/README.md
+++ b/packages/ra-data-fakerest/README.md
@@ -109,6 +109,21 @@ const App = () => (
 );
 ```
 
+### Random delay
+
+You can also pass `true` to use a random delay between 500ms and 1500ms, or an object `{ min: number, max: number }` to specify a custom range.
+
+```jsx
+// random delay between 500ms and 1500ms
+const dataProvider2 = fakeDataProvider({ /* data here */ }, false, true);
+
+// random delay between 200ms and 1000ms
+const dataProvider3 = fakeDataProvider({ /* data here */ }, false, { min: 200, max: 1000 });
+
+// random delay between 0 and 500ms (max only)
+const dataProvider4 = fakeDataProvider({ /* data here */ }, false, { max: 500 });
+```
+
 ## Inspecting the Data
 
 `ra-data-fakerest` makes its internal database accessible in the global scope under the `_database` key. You can use it to inspect the data in your browser console.

--- a/packages/ra-data-fakerest/src/index.spec.ts
+++ b/packages/ra-data-fakerest/src/index.spec.ts
@@ -63,4 +63,42 @@ describe('ra-data-fakerest', () => {
             }).rejects.toThrow();
         });
     });
+
+    describe('delay', () => {
+        it.each([
+            { label: 'undefined', delay: undefined, min: 0, max: 20 },
+            { label: 'false', delay: false, min: 0, max: 20 },
+            { label: 'number', delay: 100, min: 100, max: 150 },
+            { label: 'true', delay: true, min: 500, max: 1550 },
+            {
+                label: 'object',
+                delay: { min: 100, max: 200 },
+                min: 100,
+                max: 250,
+            },
+            { label: 'min 0', delay: { min: 0, max: 100 }, min: 0, max: 150 },
+            { label: 'min only', delay: { min: 100 }, min: 100, max: 150 },
+            { label: 'max only', delay: { max: 100 }, min: 0, max: 150 },
+            { label: 'empty object', delay: {}, min: 0, max: 20 },
+        ])(
+            'should delay the response correctly when delay is $label',
+            async ({ delay, min, max }) => {
+                const dataProvider = fakerestDataProvider(
+                    { posts: [{ id: 0, title: 'Hello, world!' }] },
+                    false,
+                    delay
+                );
+                const start = Date.now();
+                await dataProvider.getOne('posts', { id: 0 });
+                const end = Date.now();
+                const duration = end - start;
+
+                expect(duration).toBeGreaterThanOrEqual(min);
+                if (max > 20) {
+                    // Only check max for non-immediate responses to avoid flakiness
+                    expect(duration).toBeLessThanOrEqual(max);
+                }
+            }
+        );
+    });
 });


### PR DESCRIPTION
## Problem

Previously, `ra-data-fakerest` only supported a fixed delay (in milliseconds). This made it difficult to simulate more realistic, variable network conditions during development or end-to-end testing.

## Solution

This PR enhances the `delay` parameter of the `fakeDataProvider` to support random ranges:

```typescript
type Delay = number | boolean | { min?: number; max?: number };
```
`number`: Remains supported for fixed delays (backward compatible).
`boolean`: Passing true enables a default random delay between 500ms and 1500ms.
`object`: Passing { min: number, max: number } allows setting a custom random range.


## How To Test

Added a parameterized test to `packages/ra-data-fakerest/src/index.spec.ts` to ensure all scenarios are covered with no breaking changes.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
    - Not a bugfix, but a backwards-compatible new feature.
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
    - Not applicable for this data provider change; behavior is fully verified via unit tests.
- [x] The **documentation** is up to date
    - Updated README.md with examples

