### PR TITLE
Fix `<DataTableBase>` `loading` and `empty` components miss access to data table context

### DIFF
--- a/packages/ra-core/src/dataTable/DataTableBase.spec.tsx
+++ b/packages/ra-core/src/dataTable/DataTableBase.spec.tsx
@@ -1,0 +1,200 @@
+import * as React from 'react';
+import expect from 'expect';
+import { render, screen } from '@testing-library/react';
+import { DataTableBase } from './DataTableBase';
+import { ResourceContextProvider, useResourceContext } from '../core';
+import { ListContextProvider } from '../controller';
+
+describe('<DataTableBase>', () => {
+    const defaultListContext = {
+        resource: 'posts',
+        data: [],
+        total: 0,
+        isPending: false,
+        isFetching: false,
+        sort: { field: 'id', order: 'ASC' },
+    };
+
+    it('should render children when data is present', () => {
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={
+                        {
+                            ...defaultListContext,
+                            data: [{ id: 1 }],
+                            total: 1,
+                        } as any
+                    }
+                >
+                    <DataTableBase
+                        empty={<div>Empty</div>}
+                        loading={<div>Loading</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Child Content</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Child Content')).not.toBeNull();
+        expect(screen.queryByText('Loading')).toBeNull();
+        expect(screen.queryByText('Empty')).toBeNull();
+    });
+
+    it('should render empty component when no data', () => {
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={{ ...defaultListContext, data: [], total: 0 } as any}
+                >
+                    <DataTableBase
+                        empty={<div>Empty Component</div>}
+                        loading={<div>Loading</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Child</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Empty Component')).not.toBeNull();
+        expect(screen.queryByText('Child')).toBeNull();
+    });
+
+    it('should render loading component when pending', () => {
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={{ ...defaultListContext, isPending: true } as any}
+                >
+                    <DataTableBase
+                        empty={<div>Empty</div>}
+                        loading={<div>Loading Component</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Child</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Loading Component')).not.toBeNull();
+        expect(screen.queryByText('Child')).toBeNull();
+    });
+
+    it('should display the empty component instead of the table header when loaded with no data', () => {
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={
+                        {
+                            ...defaultListContext,
+                            data: [],
+                            total: 0,
+                            isPending: false,
+                        } as any
+                    }
+                >
+                    <DataTableBase
+                        empty={<div>Empty Component</div>}
+                        loading={<div>Loading</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Table Header and Body</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Empty Component')).not.toBeNull();
+        expect(screen.queryByText('Table Header and Body')).toBeNull();
+    });
+
+    it('should display the current data when data is refreshing', () => {
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={
+                        {
+                            ...defaultListContext,
+                            data: [{ id: 1 }],
+                            total: 1,
+                            isPending: false,
+                            isFetching: true,
+                        } as any
+                    }
+                >
+                    <DataTableBase
+                        empty={<div>Empty</div>}
+                        loading={<div>Loading Component</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Child Content</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Child Content')).not.toBeNull();
+        expect(screen.queryByText('Loading Component')).toBeNull();
+    });
+
+    it('should provide ResourceContext to the loading component', () => {
+        const Loading = () => {
+            const resource = useResourceContext();
+            return <div>Loading resource: {resource}</div>;
+        };
+
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={{ ...defaultListContext, isPending: true } as any}
+                >
+                    <DataTableBase
+                        empty={<div>Empty</div>}
+                        loading={<Loading />}
+                        hasBulkActions={false}
+                    >
+                        <div>Child</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Loading resource: posts')).not.toBeNull();
+    });
+
+    it('should provide ResourceContext to the empty component', () => {
+        const Empty = () => {
+            const resource = useResourceContext();
+            return <div>Empty resource: {resource}</div>;
+        };
+
+        render(
+            <ResourceContextProvider value="posts">
+                <ListContextProvider
+                    value={
+                        {
+                            ...defaultListContext,
+                            isPending: false,
+                            data: [],
+                        } as any
+                    }
+                >
+                    <DataTableBase
+                        empty={<Empty />}
+                        loading={<div>Loading</div>}
+                        hasBulkActions={false}
+                    >
+                        <div>Child</div>
+                    </DataTableBase>
+                </ListContextProvider>
+            </ResourceContextProvider>
+        );
+
+        expect(screen.queryByText('Empty resource: posts')).not.toBeNull();
+    });
+});

--- a/packages/ra-core/src/dataTable/DataTableBase.spec.tsx
+++ b/packages/ra-core/src/dataTable/DataTableBase.spec.tsx
@@ -15,6 +15,16 @@ describe('<DataTableBase>', () => {
         sort: { field: 'id', order: 'ASC' },
     };
 
+    const DataTable = () => (
+        <DataTableBase
+            empty={<div>Empty</div>}
+            loading={<div>Loading</div>}
+            hasBulkActions={false}
+        >
+            <div>Child Content</div>
+        </DataTableBase>
+    );
+
     it('should render children when data is present', () => {
         render(
             <ResourceContextProvider value="posts">
@@ -27,13 +37,7 @@ describe('<DataTableBase>', () => {
                         } as any
                     }
                 >
-                    <DataTableBase
-                        empty={<div>Empty</div>}
-                        loading={<div>Loading</div>}
-                        hasBulkActions={false}
-                    >
-                        <div>Child Content</div>
-                    </DataTableBase>
+                    <DataTable />
                 </ListContextProvider>
             </ResourceContextProvider>
         );
@@ -49,19 +53,14 @@ describe('<DataTableBase>', () => {
                 <ListContextProvider
                     value={{ ...defaultListContext, data: [], total: 0 } as any}
                 >
-                    <DataTableBase
-                        empty={<div>Empty Component</div>}
-                        loading={<div>Loading</div>}
-                        hasBulkActions={false}
-                    >
-                        <div>Child</div>
-                    </DataTableBase>
+                    <DataTable />
                 </ListContextProvider>
             </ResourceContextProvider>
         );
 
-        expect(screen.queryByText('Empty Component')).not.toBeNull();
-        expect(screen.queryByText('Child')).toBeNull();
+        expect(screen.queryByText('Child Content')).toBeNull();
+        expect(screen.queryByText('Loading')).toBeNull();
+        expect(screen.queryByText('Empty')).not.toBeNull();
     });
 
     it('should render loading component when pending', () => {
@@ -70,47 +69,14 @@ describe('<DataTableBase>', () => {
                 <ListContextProvider
                     value={{ ...defaultListContext, isPending: true } as any}
                 >
-                    <DataTableBase
-                        empty={<div>Empty</div>}
-                        loading={<div>Loading Component</div>}
-                        hasBulkActions={false}
-                    >
-                        <div>Child</div>
-                    </DataTableBase>
+                    <DataTable />
                 </ListContextProvider>
             </ResourceContextProvider>
         );
 
-        expect(screen.queryByText('Loading Component')).not.toBeNull();
-        expect(screen.queryByText('Child')).toBeNull();
-    });
-
-    it('should display the empty component instead of the table header when loaded with no data', () => {
-        render(
-            <ResourceContextProvider value="posts">
-                <ListContextProvider
-                    value={
-                        {
-                            ...defaultListContext,
-                            data: [],
-                            total: 0,
-                            isPending: false,
-                        } as any
-                    }
-                >
-                    <DataTableBase
-                        empty={<div>Empty Component</div>}
-                        loading={<div>Loading</div>}
-                        hasBulkActions={false}
-                    >
-                        <div>Table Header and Body</div>
-                    </DataTableBase>
-                </ListContextProvider>
-            </ResourceContextProvider>
-        );
-
-        expect(screen.queryByText('Empty Component')).not.toBeNull();
-        expect(screen.queryByText('Table Header and Body')).toBeNull();
+        expect(screen.queryByText('Child Content')).toBeNull();
+        expect(screen.queryByText('Loading')).not.toBeNull();
+        expect(screen.queryByText('Empty')).toBeNull();
     });
 
     it('should display the current data when data is refreshing', () => {
@@ -127,19 +93,14 @@ describe('<DataTableBase>', () => {
                         } as any
                     }
                 >
-                    <DataTableBase
-                        empty={<div>Empty</div>}
-                        loading={<div>Loading Component</div>}
-                        hasBulkActions={false}
-                    >
-                        <div>Child Content</div>
-                    </DataTableBase>
+                    <DataTable />
                 </ListContextProvider>
             </ResourceContextProvider>
         );
 
         expect(screen.queryByText('Child Content')).not.toBeNull();
-        expect(screen.queryByText('Loading Component')).toBeNull();
+        expect(screen.queryByText('Loading')).toBeNull();
+        expect(screen.queryByText('Empty')).toBeNull();
     });
 
     it('should provide ResourceContext to the loading component', () => {

--- a/packages/ra-core/src/dataTable/DataTableBase.tsx
+++ b/packages/ra-core/src/dataTable/DataTableBase.tsx
@@ -145,43 +145,43 @@ export const DataTableBase = function DataTable<
         ]
     );
 
-    if (isPending === true) {
-        return loading;
-    }
-
-    /**
-     * Once loaded, the data for the list may be empty. Instead of
-     * displaying the table header with zero data rows,
-     * the DataTable displays the empty component.
-     */
-    if (data == null || data.length === 0 || total === 0) {
-        return empty ?? null;
-    }
-
-    /**
-     * After the initial load, if the data for the list isn't empty,
-     * and even if the data is refreshing (e.g. after a filter change),
-     * the DataTable displays the current data.
-     */
     return (
         <DataTableStoreContext.Provider value={storeContextValue}>
-            <DataTableSortContext.Provider value={sort}>
-                <DataTableSelectedIdsContext.Provider value={selectedIds}>
-                    <DataTableCallbacksContext.Provider
-                        value={callbacksContextValue}
-                    >
-                        <DataTableConfigContext.Provider
-                            value={configContextValue}
-                        >
-                            <OptionalResourceContextProvider value={resource}>
-                                <DataTableDataContext.Provider value={data}>
-                                    {children}
-                                </DataTableDataContext.Provider>
-                            </OptionalResourceContextProvider>
-                        </DataTableConfigContext.Provider>
-                    </DataTableCallbacksContext.Provider>
-                </DataTableSelectedIdsContext.Provider>
-            </DataTableSortContext.Provider>
+            <DataTableConfigContext.Provider value={configContextValue}>
+                <OptionalResourceContextProvider value={resource}>
+                    {isPending ? (
+                        loading
+                    ) : data == null || data.length === 0 || total === 0 ? (
+                        /**
+                         * Once loaded, the data for the list may be empty.
+                         * Instead of displaying the table header
+                         * with zero data rows, the DataTable
+                         * displays the empty component.
+                         */
+                        empty
+                    ) : (
+                        /**
+                         * After the initial load, if the data for the list
+                         * isn't empty, and even if the data is refreshing
+                         * (e.g. after a filter change), the DataTable
+                         * displays the current data.
+                         */
+                        <DataTableSortContext.Provider value={sort}>
+                            <DataTableCallbacksContext.Provider
+                                value={callbacksContextValue}
+                            >
+                                <DataTableSelectedIdsContext.Provider
+                                    value={selectedIds}
+                                >
+                                    <DataTableDataContext.Provider value={data}>
+                                        {children}
+                                    </DataTableDataContext.Provider>
+                                </DataTableSelectedIdsContext.Provider>
+                            </DataTableCallbacksContext.Provider>
+                        </DataTableSortContext.Provider>
+                    )}
+                </OptionalResourceContextProvider>
+            </DataTableConfigContext.Provider>
         </DataTableStoreContext.Provider>
     );
 };

--- a/packages/ra-core/src/dataTable/DataTableBase.tsx
+++ b/packages/ra-core/src/dataTable/DataTableBase.tsx
@@ -158,7 +158,7 @@ export const DataTableBase = function DataTable<
                          * with zero data rows, the DataTable
                          * displays the empty component.
                          */
-                        empty
+                        empty ?? null
                     ) : (
                         /**
                          * After the initial load, if the data for the list


### PR DESCRIPTION
This change ensures that custom loading and empty components in `DataTableBase` have access to relevant table contexts.

This should be fully backwards compatible.

## Problem
When providing custom `loading` or `empty` components to `DataTableBase`, these components did not have access to any contexts. Some of these contexts, namely resource, table store, and table config, might be valuable when rendering Empty/Loading states. This lack of access forced developers to pass props manually or duplicate logic if they wanted to use this context within their components.

## Solution
Updated `DataTableBase` in `packages/ra-core` to wrap the `loading` and `empty` rendering logic with the following context providers:
- `DataTableStoreContext.Provider`
- `DataTableConfigContext.Provider`
- `OptionalResourceContextProvider`

This ensures that any component rendered in these slots can access the current resource and configuration from context.


## How To Test
I have added a new test file `packages/ra-core/src/dataTable/DataTableBase.spec.tsx` which covers:
- **Context Availability**: Verifies that context is correctly resolved by components rendered in the `loading` and `empty` slots.
- **Rendering Logic**: Verifies existing behavior (now covered by unit tests):
    - Children are rendered when data is present.
    - The `loading` component is rendered when pending.
    - The `empty` component is rendered when no data is present (hiding headers).
    - Data is still displayed while refreshing (fetching but not pending).
