### PR TITLE
test: cover List empty state with permanent filters

### DIFF
--- a/packages/ra-ui-materialui/src/list/List.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/List.spec.tsx
@@ -237,6 +237,36 @@ describe('<List />', () => {
                 screen.getByText('dummy');
             });
         });
+
+        it('should render the empty component when only a permanent filter is set', async () => {
+            const Dummy = () => {
+                const { isPending } = useListContext();
+                return <div>{isPending ? 'loading' : 'dummy'}</div>;
+            };
+            const CustomEmpty = () => <div>Custom Empty</div>;
+            const dataProvider = {
+                getList: jest.fn(() => Promise.resolve({ data: [], total: 0 })),
+            } as any;
+
+            render(
+                <CoreAdminContext dataProvider={dataProvider}>
+                    <ThemeProvider theme={theme}>
+                        <List
+                            resource="posts"
+                            filter={{ is_published: true }}
+                            empty={<CustomEmpty />}
+                        >
+                            <Dummy />
+                        </List>
+                    </ThemeProvider>
+                </CoreAdminContext>
+            );
+
+            await waitFor(() => {
+                expect(screen.queryByText('dummy')).toBeNull();
+                screen.getByText('Custom Empty');
+            });
+        });
     });
 
     it('should render a filter button/form combo when passed an element in filters', async () => {


### PR DESCRIPTION
## Summary
- add a regression test for the List empty state when only a permanent `filter` prop is set
- confirm the custom empty component still renders when there are no results and no user-applied filters

## How To Test
- `corepack yarn test-unit-ci packages/ra-ui-materialui/src/list/List.spec.tsx`
- `corepack yarn exec prettier --check packages/ra-ui-materialui/src/list/List.spec.tsx`

## Notes
This does not change runtime behavior. It adds coverage for issue #8320, which appears to already be fixed in current `master`.

Closes #8320
