### PR TITLE
chore: deprecate loading prop in EditBase and clarify usage

### DIFF
--- a/packages/ra-core/src/controller/create/CreateBase.tsx
+++ b/packages/ra-core/src/controller/create/CreateBase.tsx
@@ -99,8 +99,10 @@ export interface CreateBaseProps<
     children?: ReactNode;
     render?: (props: CreateControllerResult<RecordType>) => ReactNode;
     authLoading?: ReactNode;
-    /**
-     * @deprecated use authLoading instead
-     */
+	
+	/**
+	 * @deprecated use the `saving` boolean returned by useCreateController instead.
+	 * For authentication-related loading states, use `authLoading`.
+	 */
     loading?: ReactNode;
 }

--- a/packages/ra-core/src/controller/edit/EditBase.tsx
+++ b/packages/ra-core/src/controller/edit/EditBase.tsx
@@ -111,7 +111,12 @@ export interface EditBaseProps<
     ErrorType = Error,
 > extends EditControllerProps<RecordType, ErrorType> {
     authLoading?: ReactNode;
-    loading?: ReactNode;
+	
+	/**
+	 * @deprecated use the `saving` boolean returned by useEditController instead.
+	 * For authentication-related loading states, use `authLoading`.
+	 */
+	loading?: ReactNode;
     offline?: ReactNode;
     error?: ReactNode;
     children?: ReactNode;


### PR DESCRIPTION
This PR aligns CreateBase and EditBase regarding the `loading` prop.

Changes:
- Deprecates `loading` in EditBase (already deprecated in CreateBase)
- Clarifies deprecation comments in both components

The `loading` prop is replaced by:
- the `saving` boolean returned by useCreateController/useEditController
- `authLoading` for authentication-related loading states

This improves API consistency and clarifies intended usage.

No runtime behavior changes.