### PR TITLE
Fix typos in the RichTextInput docs

### DIFF
--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -122,7 +122,7 @@ export const MyEditorOptions = {
 
 The `<RichTextInput>` component has a `toolbar` prop that accepts a `ReactNode`. By default, it uses the `<RichTextInputToolbar>` component.
 
-You can leverage the `toolbar` prop to change the button size:
+You can leverage the `toolbar` prop to change the buttons size:
 
 ```jsx
 import { Edit, SimpleForm, TextInput } from 'react-admin';

--- a/docs/RichTextInput.md
+++ b/docs/RichTextInput.md
@@ -120,9 +120,9 @@ export const MyEditorOptions = {
 
 ## `toolbar`
 
-The `<RichTextInput>` component has a `toolbar` prop that accepts a `ReactNode`. But default, it uses the `<RichTextInputToolbar>` component.
+The `<RichTextInput>` component has a `toolbar` prop that accepts a `ReactNode`. By default, it uses the `<RichTextInputToolbar>` component.
 
-You can leverage the `tollbar` prop to change the buttons size:
+You can leverage the `toolbar` prop to change the button size:
 
 ```jsx
 import { Edit, SimpleForm, TextInput } from 'react-admin';


### PR DESCRIPTION
## Summary
- replace "But default" with "By default" in the toolbar section
- fix the `toolbar` prop typo in the same section

Closes #11247
