### PR TITLE
Fix AutoCompleteInput value does not get updated when re-selecting the same option

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -30,6 +30,7 @@ import {
     CreateLabel,
     CreateItemLabel,
     CreateItemLabelRendered,
+    FilterSelectedOptionsFalse,
 } from './AutocompleteInput.stories';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
@@ -82,53 +83,28 @@ describe('<AutocompleteInput />', () => {
     });
 
     it('should immediately update input value when re-selecting the same option after partial deletion with filterSelectedOptions={false}', async () => {
-        render(
-            <AdminContext dataProvider={testDataProvider()}>
-                <ResourceContextProvider value="posts">
-                    <SimpleForm>
-                        <AutocompleteInput
-                            {...defaultProps}
-                            choices={[
-                                { id: 1, name: 'foo' },
-                                { id: 2, name: 'bar' },
-                            ]}
-                            filterSelectedOptions={false}
-                        />
-                    </SimpleForm>
-                </ResourceContextProvider>
-            </AdminContext>
-        );
+        render(<FilterSelectedOptionsFalse />);
 
-        const input = screen.getByLabelText(
-            'resources.users.fields.role'
-        ) as HTMLInputElement;
+        // Wait for the Edit form to load — record has author: 1 (Leo Tolstoy)
+        const input = (await screen.findByDisplayValue(
+            'Leo Tolstoy'
+        )) as HTMLInputElement;
 
-        // Select 'foo' initially
-        fireEvent.mouseDown(input);
-        await waitFor(() => {
-            expect(screen.queryByText('foo')).not.toBeNull();
-        });
-        fireEvent.click(screen.getByText('foo'));
-        await waitFor(() => {
-            expect(input.value).toEqual('foo');
-        });
-
-        // Delete last character to get 'fo' using keyboard (avoids controlled-input issues)
+        // Delete last character to trigger the filter while keeping the option visible
         fireEvent.focus(input);
         userEvent.type(input, '{end}');
         userEvent.type(input, '{backspace}');
         await waitFor(() => {
-            expect(input.value).toEqual('fo');
+            expect(input.value).toEqual('Leo Tolsto');
         });
 
-        // Re-select the same 'foo' option - input should update immediately without blur
+        // Re-select the same option — input should restore immediately without blur
         await waitFor(() => {
-            expect(screen.queryByText('foo')).not.toBeNull();
+            expect(screen.queryByText('Leo Tolstoy')).not.toBeNull();
         });
-        fireEvent.click(screen.getByText('foo'));
-        // Input should immediately show 'foo' WITHOUT needing a blur event
+        fireEvent.click(screen.getByText('Leo Tolstoy'));
         await waitFor(() => {
-            expect(input.value).toEqual('foo');
+            expect(input.value).toEqual('Leo Tolstoy');
         });
         expect(document.activeElement).toBe(input);
     });

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -81,6 +81,58 @@ describe('<AutocompleteInput />', () => {
         expect(screen.queryByDisplayValue('foo')).not.toBeNull();
     });
 
+    it('should immediately update input value when re-selecting the same option after partial deletion with filterSelectedOptions={false}', async () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm>
+                        <AutocompleteInput
+                            {...defaultProps}
+                            choices={[
+                                { id: 1, name: 'foo' },
+                                { id: 2, name: 'bar' },
+                            ]}
+                            filterSelectedOptions={false}
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+
+        const input = screen.getByLabelText(
+            'resources.users.fields.role'
+        ) as HTMLInputElement;
+
+        // Select 'foo' initially
+        fireEvent.mouseDown(input);
+        await waitFor(() => {
+            expect(screen.queryByText('foo')).not.toBeNull();
+        });
+        fireEvent.click(screen.getByText('foo'));
+        await waitFor(() => {
+            expect(input.value).toEqual('foo');
+        });
+
+        // Delete last character to get 'fo' using keyboard (avoids controlled-input issues)
+        fireEvent.focus(input);
+        userEvent.type(input, '{end}');
+        userEvent.type(input, '{backspace}');
+        await waitFor(() => {
+            expect(input.value).toEqual('fo');
+        });
+
+        // Re-select the same 'foo' option - input should update immediately without blur
+        await waitFor(() => {
+            expect(screen.queryByText('foo')).not.toBeNull();
+        });
+        fireEvent.click(screen.getByText('foo'));
+        // Input should immediately show 'foo' WITHOUT needing a blur event
+        await waitFor(() => {
+            expect(input.value).toEqual('foo');
+        });
+        expect(document.activeElement).toBe(input);
+    });
+
     it('should allow filter to match the selected choice while removing characters in the input', async () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -1493,7 +1493,7 @@ export const OutlinedNoLabel = () => (
 
 // Regression test: with filterSelectedOptions=false, partially deleting the input text
 // and re-selecting the same option should restore the full label immediately (without blur).
-export const ReSelectSameOptionWithFilterSelectedOptionsFalse = () => (
+export const FilterSelectedOptionsFalse = () => (
     <Wrapper>
         <AutocompleteInput
             source="author"

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -1490,3 +1490,16 @@ export const OutlinedNoLabel = () => (
         />
     </Wrapper>
 );
+
+// Regression test: with filterSelectedOptions=false, partially deleting the input text
+// and re-selecting the same option should restore the full label immediately (without blur).
+export const ReSelectSameOptionWithFilterSelectedOptionsFalse = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={defaultChoices}
+            filterSelectedOptions={false}
+            helperText="Select an author, partially delete the name, then re-select the same option — the input should restore immediately"
+        />
+    </Wrapper>
+);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -520,6 +520,21 @@ If you provided a React element for the optionText prop, you must also provide t
             setFilterValue('');
             debouncedSetFilter('');
         }
+        // When filterSelectedOptions=false, a user can delete characters from the input
+        // and re-select the same option — the input should update immediately without blur.
+        // MUI fires reason='reset' (not 'selectOption') for this case.
+        // - event !== null: MUI's useEffect also fires reason='reset' with event=null for
+        //   programmatic value resets, which should not update the filter.
+        // - doesQueryMatchSelection: when a create option is clicked, MUI fires reason='reset'
+        //   with the create label as newInputValue, which should not override the user's text.
+        if (
+            reason === 'reset' &&
+            event !== null &&
+            doesQueryMatchSelection(newInputValue)
+        ) {
+            setFilterValue(newInputValue);
+            debouncedSetFilter('');
+        }
         onInputChange?.(event, newInputValue, reason);
     });
 


### PR DESCRIPTION
## Problem

See original problem in https://github.com/marmelab/react-admin/issues/11209
Closes https://github.com/marmelab/react-admin/issues/11209

## Solution

Add additional check for handleInputChange with the condition reason='reset'

## How To Test

  1. Open the FilterSelectedOptionsFalse story in Storybook.
  2. The input starts with a pre-selected author (e.g. "Leo Tolstoy").
  3. Click into the input and delete one character (e.g. → "Leo Tolsto"). The dropdown should remain open showing "Leo
  Tolstoy".
  4. Click "Leo Tolstoy" in the dropdown.
  5. Expected: the input immediately shows "Leo Tolstoy" and focus stays in the field.
  6. Before this fix: the input stayed at "Leo Tolsto" until blur.


## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date
