### PR TITLE
fix: ArrayField should use ArrayFieldProps

### DIFF
--- a/packages/ra-ui-materialui/src/field/ArrayField.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.spec.tsx
@@ -48,6 +48,22 @@ describe('<ArrayField />', () => {
         );
     });
 
+    it('should accept label prop (FieldProps)', () => {
+        // This test ensures that ArrayField accepts the label prop from FieldProps
+        // Regression test for https://github.com/marmelab/react-admin/issues/11197
+        render(
+            <Wrapper>
+                <ArrayField
+                    source="arr"
+                    label="My Array"
+                    record={{ id: 123, arr: [{ id: 1, foo: 'bar' }] }}
+                >
+                    <DummyIterator />
+                </ArrayField>
+            </Wrapper>
+        );
+    });
+
     it('should not fail when value is null', () => {
         render(
             <Wrapper>

--- a/packages/ra-ui-materialui/src/field/ArrayField.tsx
+++ b/packages/ra-ui-materialui/src/field/ArrayField.tsx
@@ -1,3 +1,4 @@
+import * as React from 'react';
 import { ArrayFieldBase, type ArrayFieldBaseProps } from 'ra-core';
 
 import type { FieldProps } from './types';
@@ -23,7 +24,11 @@ import type { FieldProps } from './types';
  *
  * @see useListContext
  */
-export const ArrayField = ArrayFieldBase;
+export const ArrayField = ArrayFieldBase as unknown as <
+    RecordType extends Record<string, any> = Record<string, any>,
+>(
+    props: ArrayFieldProps<RecordType>
+) => React.ReactElement;
 
 export interface ArrayFieldProps<
     RecordType extends Record<string, any> = Record<string, any>,


### PR DESCRIPTION
## Problem

Fixes #11232

## Solution

Cast `ArrayField` props to `ArrayFieldBase`

## How To Test

_Describe the steps required to test the changes_

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests**
- [ ] The PR includes one or several **stories** — type-only fix, no visual change
- [x] The **documentation** is up to date — no API change

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
