### PR TITLE
Fix(AutocompleteInput): do not open autocomplete options when shouldRenderSuggestions returns false

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -708,17 +708,19 @@ describe('<AutocompleteInput />', () => {
         });
     });
 
-    it('should respect shouldRenderSuggestions over default if passed in', async () => {
+    it('should not open the suggestions popper when shouldRenderSuggestions returns false', async () => {
         render(
             <AdminContext dataProvider={testDataProvider()}>
                 <ResourceContextProvider value="posts">
                     <SimpleForm
                         onSubmit={jest.fn()}
-                        defaultValues={{ role: 2 }}
+                        defaultValues={{ role: null }}
                     >
                         <AutocompleteInput
                             {...defaultProps}
-                            shouldRenderSuggestions={() => false}
+                            shouldRenderSuggestions={(v: string) =>
+                                v.length >= 2
+                            }
                             noOptionsText="No options"
                             choices={[
                                 { id: 1, name: 'bar' },
@@ -730,11 +732,21 @@ describe('<AutocompleteInput />', () => {
             </AdminContext>
         );
 
-        const input = screen.getByLabelText('resources.users.fields.role');
+        const input = screen.getByLabelText(
+            'resources.users.fields.role'
+        ) as HTMLInputElement;
         fireEvent.focus(input);
+
+        // popper must NOT open while shouldRenderSuggestions returns false
+        expect(screen.queryByRole('listbox')).toBeNull();
+        expect(screen.queryByText('No options')).toBeNull();
+
+        // typing 2+ chars satisfies the predicate -> popper opens
+        fireEvent.change(input, { target: { value: 'fo' } });
         await waitFor(() => {
-            expect(screen.queryByText('foo')).toBeNull();
+            expect(screen.queryByRole('listbox')).not.toBeNull();
         });
+        expect(screen.queryByText('foo')).not.toBeNull();
     });
 
     it('should not fail when value is null and new choices are applied', () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -878,6 +878,39 @@ export const InsideReferenceInputWithDisableChoice = () => (
     </TestMemoryRouter>
 );
 
+const enableGetChoicesMinTwoChars = (filters: any) => filters?.q?.length >= 2;
+const shouldRenderSuggestionsMinTwoChars = (v: string) => v.length >= 2;
+
+export const InsideReferenceInputWithShouldRenderSuggestions = () => (
+    <TestMemoryRouter initialEntries={['/books/1']}>
+        <Admin dataProvider={dataProviderWithAuthors}>
+            <Resource name="authors" />
+            <Resource
+                name="books"
+                edit={() => (
+                    <Edit mutationMode="pessimistic">
+                        <SimpleForm>
+                            <ReferenceInput
+                                reference="authors"
+                                source="author"
+                                enableGetChoices={enableGetChoicesMinTwoChars}
+                            >
+                                <AutocompleteInput
+                                    optionText="name"
+                                    noOptionsText="Type 2+ chars to search"
+                                    shouldRenderSuggestions={
+                                        shouldRenderSuggestionsMinTwoChars
+                                    }
+                                />
+                            </ReferenceInput>
+                        </SimpleForm>
+                    </Edit>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
 const LanguageChangingAuthorInput = ({ onChange }) => {
     const { setValue } = useFormContext();
     const handleChange = (value, record) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -343,7 +343,8 @@ If you provided a React element for the optionText prop, you must also provide t
 
     const [isOpen, setIsOpen] = useState(false);
     const canRenderSuggestions =
-        !shouldRenderSuggestions || shouldRenderSuggestions(filterValue);
+        shouldRenderSuggestions == undefined || // eslint-disable-line eqeqeq
+        shouldRenderSuggestions(filterValue);
 
     const handleOpen = useEvent((event: React.SyntheticEvent) => {
         setIsOpen(true);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -1,25 +1,12 @@
-import * as React from 'react';
-import {
-    isValidElement,
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type ReactNode,
-} from 'react';
-import debounce from 'lodash/debounce.js';
-import get from 'lodash/get.js';
-import isEqual from 'lodash/isEqual.js';
-import clsx from 'clsx';
 import {
     Autocomplete,
     type AutocompleteChangeReason,
+    type AutocompleteCloseReason,
     type AutocompleteProps,
     Chip,
+    createFilterOptions,
     TextField,
     type TextFieldProps,
-    createFilterOptions,
     useForkRef,
 } from '@mui/material';
 import {
@@ -27,26 +14,40 @@ import {
     styled,
     useThemeProps,
 } from '@mui/material/styles';
+import clsx from 'clsx';
+import debounce from 'lodash/debounce.js';
+import get from 'lodash/get.js';
+import isEqual from 'lodash/isEqual.js';
 import {
     type ChoicesProps,
     FieldTitle,
     type RaRecord,
+    type SupportCreateSuggestionOptions,
     useChoicesContext,
+    useEvent,
+    useGetRecordRepresentation,
     useInput,
     useSuggestions,
     type UseSuggestionsOptions,
+    useSupportCreateSuggestion,
     useTimeout,
     useTranslate,
     warning,
-    useGetRecordRepresentation,
-    useEvent,
-    type SupportCreateSuggestionOptions,
-    useSupportCreateSuggestion,
 } from 'ra-core';
+import * as React from 'react';
+import {
+    isValidElement,
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { Offline } from '../Offline';
 import type { CommonInputProps } from './CommonInputProps';
 import { InputHelperText } from './InputHelperText';
 import { sanitizeInputRestProps } from './sanitizeInputRestProps';
-import { Offline } from '../Offline';
 
 const defaultFilterOptions = createFilterOptions();
 
@@ -171,7 +172,9 @@ export const AutocompleteInput = <
         offline = defaultOffline,
         onBlur,
         onChange,
+        onClose: onCloseProp,
         onCreate,
+        onOpen: onOpenProp,
         openText = 'ra.action.open',
         optionText,
         optionValue,
@@ -337,6 +340,22 @@ If you provided a React element for the optionText prop, you must also provide t
     });
 
     const [filterValue, setFilterValue] = useState('');
+
+    const [isOpen, setIsOpen] = useState(false);
+    const canRenderSuggestions =
+        !shouldRenderSuggestions || shouldRenderSuggestions(filterValue);
+
+    const handleOpen = useEvent((event: React.SyntheticEvent) => {
+        setIsOpen(true);
+        onOpenProp?.(event);
+    });
+
+    const handleClose = useEvent(
+        (event: React.SyntheticEvent, reason: AutocompleteCloseReason) => {
+            setIsOpen(false);
+            onCloseProp?.(event, reason);
+        }
+    );
 
     const handleChange = useEvent((newValue: any) => {
         if (multiple) {
@@ -755,13 +774,15 @@ If you provided a React element for the optionText prop, you must also provide t
                 clearOnBlur={clearOnBlur}
                 {...sanitizeInputRestProps(rest)}
                 freeSolo={!!create || !!onCreate}
+                open={isOpen && canRenderSuggestions}
+                onOpen={handleOpen}
+                onClose={handleClose}
                 handleHomeEndKeys={!!create || !!onCreate}
                 filterOptions={filterOptions}
                 options={
                     isPaused && isPlaceholderData
                         ? []
-                        : shouldRenderSuggestions == undefined || // eslint-disable-line eqeqeq
-                            shouldRenderSuggestions(filterValue)
+                        : canRenderSuggestions
                           ? suggestions
                           : []
                 }


### PR DESCRIPTION
## Problem

The suggestions ("No options"/"Please wait") keep appearing despite the char count is not firing the request when AutocompleteInput is inside a ReferenceInput

## Solution

Use controlled mode in Autocomplete for AutocompleteInput to avoid opening the choces when there are no options to render

## How To Test

1. `make storybook`
2. Then go to http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompleteinput--inside-reference-input-with-should-render-suggestions

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
