### PR TITLE
Fix `<ArrayInput>` display validation error when validation is performed via `useFormContext`'s trigger

### DIFF
--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.spec.tsx
@@ -26,6 +26,7 @@ import {
     Focus,
     Reset,
     ConditionalArrayInputValidationContent,
+    TriggerValidation,
 } from './ArrayInput.stories';
 
 describe('<ArrayInput />', () => {
@@ -308,6 +309,18 @@ describe('<ArrayInput />', () => {
         fireEvent.click(screen.getByText('ra.action.save'));
 
         await screen.findByText('ra.validation.required');
+    });
+
+    // Reproduces the WizardForm scenario where validation is triggered when
+    // navigating between steps without the user having interacted with the field.
+    it('should display the error after validation is triggered programmatically without user interaction', async () => {
+        render(<TriggerValidation />);
+
+        expect(screen.queryByText('Required')).toBeNull();
+
+        fireEvent.click(await screen.findByText('Validate'));
+
+        await screen.findByText('Required');
     });
 
     it('should update the form state to dirty, and allow submit, on updating an array input with default value', async () => {

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.stories.tsx
@@ -871,6 +871,45 @@ export const DisplayErrorOnlyAfterInteractionOrInvalidSubmit = () => (
     </TestMemoryRouter>
 );
 
+const TriggerValidationButton = () => {
+    const { trigger } = useFormContext();
+    return (
+        <Button onClick={() => trigger()} variant="outlined">
+            Validate
+        </Button>
+    );
+};
+
+export const TriggerValidation = () => (
+    <TestMemoryRouter initialEntries={['/books/create']}>
+        <Admin dataProvider={dataProvider}>
+            <Resource
+                name="books"
+                create={() => (
+                    <Create>
+                        <SimpleForm>
+                            <Alert severity="info" sx={{ mb: 2 }}>
+                                Reproduces the WizardForm scenario where
+                                validation is triggered programmatically (e.g.
+                                when navigating between steps) without the user
+                                having interacted with the field. Clicking
+                                &quot;Validate&quot; should display the required
+                                error on the ArrayInput.
+                            </Alert>
+                            <ArrayInput source="authors" validate={required()}>
+                                <SimpleFormIterator>
+                                    <TextInput source="name" />
+                                </SimpleFormIterator>
+                            </ArrayInput>
+                            <TriggerValidationButton />
+                        </SimpleForm>
+                    </Create>
+                )}
+            />
+        </Admin>
+    </TestMemoryRouter>
+);
+
 const CreateGlobalValidationInFormTab = () => {
     return (
         <Create

--- a/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/ArrayInput.tsx
@@ -89,6 +89,7 @@ export const ArrayInput = (inProps: ArrayInputProps) => {
     const parentSourceContext = useSourceContext();
     const finalSource = parentSourceContext.getSource(arraySource);
     const { subscribe } = useFormContext();
+    const initialCallbackHandledRef = React.useRef(false);
     const [{ error, hasBeenInteractedWith, isSubmitted }, setArrayInputState] =
         React.useState<{
             error: any;
@@ -108,10 +109,17 @@ export const ArrayInput = (inProps: ArrayInputProps) => {
                 touchedFields: true,
             },
             callback: ({ dirtyFields, errors, isSubmitted, touchedFields }) => {
+                const isInitialCallback = !initialCallbackHandledRef.current;
+                initialCallbackHandledRef.current = true;
                 const error = get(errors ?? {}, finalSource);
+                // An error appearing only after the initial subscription
+                // (i.e. not on mount) indicates validation was explicitly
+                // triggered later — e.g. via trigger() in WizardForm when
+                // navigating between steps without interacting with the field.
                 const hasBeenInteractedWith =
                     get(dirtyFields ?? {}, finalSource, false) !== false ||
-                    get(touchedFields ?? {}, finalSource, false) !== false;
+                    get(touchedFields ?? {}, finalSource, false) !== false ||
+                    (!isInitialCallback && error !== undefined);
 
                 setArrayInputState(previousState =>
                     isEqual(previousState, {


### PR DESCRIPTION
## Problem

In RA Enterprise `<WizardForm />`, when an array input is in the second step and the user clicks on the `Next` button, the array input error is not shown if it is required.

## Solution

Display the error by checking if the form has an error when validation has been triggered by a user's action.

## How To Test

1. `make storybook`
2. Go to http://localhost:9010/?path=/story/ra-ui-materialui-input-arrayinput--trigger-validation

## Additional Checks

- [X] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [X] The PR includes **unit tests** (if not possible, describe why)
- [X] The PR includes one or several **stories** (if not possible, describe why)
- [X] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
