### PR TITLE
Add render prop support to ReferenceManyCount

### DIFF
--- a/docs/ReferenceManyCount.md
+++ b/docs/ReferenceManyCount.md
@@ -66,10 +66,10 @@ export const PostList = () => (
 | ----------- | -------- | ------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------- |
 | `reference` | Required | string                                     | -                                 | Name of the related resource to fetch (e.g. `comments`)                   |
 | `target`    | Required | string                                     | -                                 | Name of the field in the related resource that points to the current one. |
-| `children`  | Optional | `ReactNode`                                | -                                 | The component used to render the count.                                   |
 | `filter`    | Optional | Object                                     | -                                 | Filter to apply to the query.                                             |
 | `link`      | Optional | bool                                       | `false`                           | If true, the count is wrapped in a `<Link>` to the filtered list view.    |
 | `offline`   | Optional | `ReactNode`                                |                                   | The component to render when there is no connectivity and the record isn't in the cache
+| `render`    | Optional | Function                                   | -                                 | Function used to render the count.                                        |
 | `resource`  | Optional | string                                     | -                                 | Resource to count. Default to the current `ResourceContext`               |
 | `sort`      | Optional | `{ field: string, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }`  | The sort option sent to `getManyReference`                                |
 | `timeout`   | Optional | number                                     | 1000                              | Number of milliseconds to wait before displaying the loading indicator.   |
@@ -78,16 +78,21 @@ export const PostList = () => (
 
 Additional props are passed to [the underlying Material UI `<Typography>` element](https://mui.com/material-ui/api/typography/).
 
-## `children`
+## `render`
 
-By default, `<ReferenceManyCount>` renders the total as a raw number. You can pass a child component to customize the rendering. `<ReferenceManyCount>` creates a `RecordContext` with a `total` field, so any Field component can read it:
+By default, `<ReferenceManyCount>` renders the total as a raw number. You can pass a `render` function to customize the rendering:
 
 ```jsx
 import { NumberField, ReferenceManyCount } from 'react-admin';
 
-<ReferenceManyCount reference="comments" target="post_id" link>
-    <NumberField source="total" locales="en-US" />
-</ReferenceManyCount>
+<ReferenceManyCount
+    reference="comments"
+    target="post_id"
+    link
+    render={({ total }) => (
+        <NumberField record={{ total }} source="total" locales="en-US" />
+    )}
+/>
 ```
 
 ## `filter`

--- a/docs/ReferenceManyCount.md
+++ b/docs/ReferenceManyCount.md
@@ -66,6 +66,7 @@ export const PostList = () => (
 | ----------- | -------- | ------------------------------------------ | --------------------------------- | ------------------------------------------------------------------------- |
 | `reference` | Required | string                                     | -                                 | Name of the related resource to fetch (e.g. `comments`)                   |
 | `target`    | Required | string                                     | -                                 | Name of the field in the related resource that points to the current one. |
+| `children`  | Optional | `ReactNode`                                | -                                 | The component used to render the count.                                   |
 | `filter`    | Optional | Object                                     | -                                 | Filter to apply to the query.                                             |
 | `link`      | Optional | bool                                       | `false`                           | If true, the count is wrapped in a `<Link>` to the filtered list view.    |
 | `offline`   | Optional | `ReactNode`                                |                                   | The component to render when there is no connectivity and the record isn't in the cache
@@ -76,6 +77,18 @@ export const PostList = () => (
 `<ReferenceManyCount>` also accepts the [common field props](./Fields.md#common-field-props).
 
 Additional props are passed to [the underlying Material UI `<Typography>` element](https://mui.com/material-ui/api/typography/).
+
+## `children`
+
+By default, `<ReferenceManyCount>` renders the total as a raw number. You can pass a child component to customize the rendering. `<ReferenceManyCount>` creates a `RecordContext` with a `total` field, so any Field component can read it:
+
+```jsx
+import { NumberField, ReferenceManyCount } from 'react-admin';
+
+<ReferenceManyCount reference="comments" target="post_id" link>
+    <NumberField source="total" locales="en-US" />
+</ReferenceManyCount>
+```
 
 ## `filter`
 

--- a/docs_headless/src/content/docs/ReferenceManyCountBase.md
+++ b/docs_headless/src/content/docs/ReferenceManyCountBase.md
@@ -60,11 +60,30 @@ export const PostList = () => (
 | ----------- | -------- | ------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
 | `reference` | Required | string                                      | -                                | Name of the related resource to fetch (e.g. `comments`)                   |
 | `target`    | Required | string                                      | -                                | Name of the field in the related resource that points to the current one. |
+| `children`  | Optional | `ReactNode`                                 | -                                | The component used to render the count.                                   |
 | `filter`    | Optional | Object                                      | -                                | Filter to apply to the query.                                             |
 | `resource`  | Optional | string                                      | -                                | Resource to count. Default to the current `ResourceContext`               |
 | `sort`      | Optional | `{ field: string, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }` | The sort option sent to `getManyReference`                                |
 | `timeout`   | Optional | number                                      | 1000                             | Number of milliseconds to wait before displaying the loading indicator.   |
 
+
+## `children`
+
+By default, `<ReferenceManyCountBase>` renders the total as a raw number. You can pass a child component to customize the rendering. `<ReferenceManyCountBase>` creates a `RecordContext` with a `total` field, so descendants can read it with `useRecordContext`:
+
+```jsx
+import { ReferenceManyCountBase, useRecordContext } from 'ra-core';
+
+const Count = () => {
+    const record = useRecordContext();
+
+    return <span>{record?.total} comments</span>;
+};
+
+<ReferenceManyCountBase reference="comments" target="post_id">
+    <Count />
+</ReferenceManyCountBase>
+```
 
 ## `filter`
 

--- a/docs_headless/src/content/docs/ReferenceManyCountBase.md
+++ b/docs_headless/src/content/docs/ReferenceManyCountBase.md
@@ -60,29 +60,25 @@ export const PostList = () => (
 | ----------- | -------- | ------------------------------------------- | -------------------------------- | ------------------------------------------------------------------------- |
 | `reference` | Required | string                                      | -                                | Name of the related resource to fetch (e.g. `comments`)                   |
 | `target`    | Required | string                                      | -                                | Name of the field in the related resource that points to the current one. |
-| `children`  | Optional | `ReactNode`                                 | -                                | The component used to render the count.                                   |
 | `filter`    | Optional | Object                                      | -                                | Filter to apply to the query.                                             |
+| `render`    | Optional | Function                                    | -                                | Function used to render the count.                                        |
 | `resource`  | Optional | string                                      | -                                | Resource to count. Default to the current `ResourceContext`               |
 | `sort`      | Optional | `{ field: string, order: 'ASC' or 'DESC' }` | `{ field: 'id', order: 'DESC' }` | The sort option sent to `getManyReference`                                |
 | `timeout`   | Optional | number                                      | 1000                             | Number of milliseconds to wait before displaying the loading indicator.   |
 
 
-## `children`
+## `render`
 
-By default, `<ReferenceManyCountBase>` renders the total as a raw number. You can pass a child component to customize the rendering. `<ReferenceManyCountBase>` creates a `RecordContext` with a `total` field, so descendants can read it with `useRecordContext`:
+By default, `<ReferenceManyCountBase>` renders the total as a raw number. You can pass a `render` function to customize the rendering:
 
 ```jsx
-import { ReferenceManyCountBase, useRecordContext } from 'ra-core';
+import { ReferenceManyCountBase } from 'ra-core';
 
-const Count = () => {
-    const record = useRecordContext();
-
-    return <span>{record?.total} comments</span>;
-};
-
-<ReferenceManyCountBase reference="comments" target="post_id">
-    <Count />
-</ReferenceManyCountBase>
+<ReferenceManyCountBase
+    reference="comments"
+    target="post_id"
+    render={({ total }) => <span>{total} comments</span>}
+/>
 ```
 
 ## `filter`

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
@@ -5,6 +5,8 @@ import {
     ErrorState,
     LoadingState,
     Offline,
+    WithChildren,
+    WithRenderFunction,
 } from './ReferenceManyCountBase.stories';
 import { onlineManager } from '@tanstack/react-query';
 
@@ -29,6 +31,16 @@ describe('ReferenceManyCountBase', () => {
     it('should render the total', async () => {
         render(<Basic />);
         await screen.findByText('3');
+    });
+
+    it('should render children in a record context containing the total', async () => {
+        render(<WithChildren />);
+        await screen.findByText('3 comments');
+    });
+
+    it('should accept a render function as children', async () => {
+        render(<WithRenderFunction />);
+        await screen.findByText('3 comments');
     });
 
     it('should render the offline prop node when offline', async () => {

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx
@@ -5,8 +5,7 @@ import {
     ErrorState,
     LoadingState,
     Offline,
-    WithChildren,
-    WithRenderFunction,
+    WithRender,
 } from './ReferenceManyCountBase.stories';
 import { onlineManager } from '@tanstack/react-query';
 
@@ -33,13 +32,8 @@ describe('ReferenceManyCountBase', () => {
         await screen.findByText('3');
     });
 
-    it('should render children in a record context containing the total', async () => {
-        render(<WithChildren />);
-        await screen.findByText('3 comments');
-    });
-
-    it('should accept a render function as children', async () => {
-        render(<WithRenderFunction />);
+    it('should accept a render function', async () => {
+        render(<WithRender />);
         await screen.findByText('3 comments');
     });
 

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.stories.tsx
@@ -4,7 +4,7 @@ import {
     QueryClient,
     onlineManager,
 } from '@tanstack/react-query';
-import { RecordContextProvider, useRecordContext } from '../record';
+import { RecordContextProvider } from '../record';
 import { DataProviderContext } from '../../dataProvider';
 import { ResourceContextProvider, useIsOffline } from '../../core';
 import { TestMemoryRouter } from '../../routing';
@@ -65,7 +65,7 @@ export const Basic = () => (
     </Wrapper>
 );
 
-export const WithChildren = () => (
+export const WithRender = () => (
     <Wrapper
         dataProvider={{
             getManyReference: () =>
@@ -75,25 +75,11 @@ export const WithChildren = () => (
                 }),
         }}
     >
-        <ReferenceManyCountBase reference="comments" target="post_id">
-            <Count />
-        </ReferenceManyCountBase>
-    </Wrapper>
-);
-
-export const WithRenderFunction = () => (
-    <Wrapper
-        dataProvider={{
-            getManyReference: () =>
-                Promise.resolve({
-                    data: [comments.filter(c => c.post_id === 1)[0]],
-                    total: comments.filter(c => c.post_id === 1).length,
-                }),
-        }}
-    >
-        <ReferenceManyCountBase reference="comments" target="post_id">
-            {({ total }) => <span>{total} comments</span>}
-        </ReferenceManyCountBase>
+        <ReferenceManyCountBase
+            reference="comments"
+            target="post_id"
+            render={({ total }) => <span>{total} comments</span>}
+        />
     </Wrapper>
 );
 
@@ -230,10 +216,4 @@ const RenderChildOnDemand = ({ children }) => {
             {showChild && <div>{children}</div>}
         </>
     );
-};
-
-const Count = () => {
-    const record = useRecordContext();
-
-    return <span>{record?.total} comments</span>;
 };

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.stories.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.stories.tsx
@@ -4,7 +4,7 @@ import {
     QueryClient,
     onlineManager,
 } from '@tanstack/react-query';
-import { RecordContextProvider } from '../record';
+import { RecordContextProvider, useRecordContext } from '../record';
 import { DataProviderContext } from '../../dataProvider';
 import { ResourceContextProvider, useIsOffline } from '../../core';
 import { TestMemoryRouter } from '../../routing';
@@ -62,6 +62,38 @@ export const Basic = () => (
         }}
     >
         <ReferenceManyCountBase reference="comments" target="post_id" />
+    </Wrapper>
+);
+
+export const WithChildren = () => (
+    <Wrapper
+        dataProvider={{
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [comments.filter(c => c.post_id === 1)[0]],
+                    total: comments.filter(c => c.post_id === 1).length,
+                }),
+        }}
+    >
+        <ReferenceManyCountBase reference="comments" target="post_id">
+            <Count />
+        </ReferenceManyCountBase>
+    </Wrapper>
+);
+
+export const WithRenderFunction = () => (
+    <Wrapper
+        dataProvider={{
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [comments.filter(c => c.post_id === 1)[0]],
+                    total: comments.filter(c => c.post_id === 1).length,
+                }),
+        }}
+    >
+        <ReferenceManyCountBase reference="comments" target="post_id">
+            {({ total }) => <span>{total} comments</span>}
+        </ReferenceManyCountBase>
     </Wrapper>
 );
 
@@ -198,4 +230,10 @@ const RenderChildOnDemand = ({ children }) => {
             {showChild && <div>{children}</div>}
         </>
     );
+};
+
+const Count = () => {
+    const record = useRecordContext();
+
+    return <span>{record?.total} comments</span>;
 };

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
@@ -4,7 +4,6 @@ import {
     type UseReferenceManyFieldControllerParams,
 } from './useReferenceManyFieldController';
 import { useTimeout } from '../../util/hooks';
-import { RecordContextProvider } from '../record';
 
 /**
  * Fetch and render the number of records related to the current one
@@ -19,7 +18,7 @@ import { RecordContextProvider } from '../record';
  */
 export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
     const {
-        children,
+        render,
         loading,
         error,
         offline,
@@ -45,9 +44,6 @@ export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
         isPending && isPaused && offline !== undefined && offline !== false;
     const shouldRenderError =
         !isPending && fetchError && error !== undefined && error !== false;
-    const totalRecord = React.useMemo(() => ({ id: 'count', total }), [total]);
-    const renderChildren =
-        typeof children === 'function' ? children(totalRecord) : children;
 
     return (
         <>
@@ -59,10 +55,8 @@ export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
                 offline
             ) : shouldRenderError ? (
                 error
-            ) : children != null ? (
-                <RecordContextProvider value={totalRecord}>
-                    {renderChildren}
-                </RecordContextProvider>
+            ) : render ? (
+                render({ total })
             ) : (
                 total
             )}
@@ -71,15 +65,12 @@ export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
 };
 
 export interface ReferenceManyCountRecord {
-    id: string;
     total: number | undefined;
 }
 
 export interface ReferenceManyCountBaseProps
     extends UseReferenceManyFieldControllerParams {
-    children?:
-        | React.ReactNode
-        | ((record: ReferenceManyCountRecord) => React.ReactNode);
+    render?: (record: ReferenceManyCountRecord) => React.ReactNode;
     timeout?: number;
     loading?: React.ReactNode;
     error?: React.ReactNode;

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
@@ -17,14 +17,7 @@ import { useTimeout } from '../../util/hooks';
  * <ReferenceManyCountBase reference="comments" target="post_id" filter={{ is_published: true }} />
  */
 export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
-    const {
-        render,
-        loading,
-        error,
-        offline,
-        timeout = 1000,
-        ...rest
-    } = props;
+    const { render, loading, error, offline, timeout = 1000, ...rest } = props;
     const oneSecondHasPassed = useTimeout(timeout);
 
     const {
@@ -47,19 +40,17 @@ export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
 
     return (
         <>
-            {shouldRenderLoading ? (
-                oneSecondHasPassed ? (
-                    loading
-                ) : null
-            ) : shouldRenderOffline ? (
-                offline
-            ) : shouldRenderError ? (
-                error
-            ) : render ? (
-                render({ total })
-            ) : (
-                total
-            )}
+            {shouldRenderLoading
+                ? oneSecondHasPassed
+                    ? loading
+                    : null
+                : shouldRenderOffline
+                  ? offline
+                  : shouldRenderError
+                    ? error
+                    : render
+                      ? render({ total })
+                      : total}
         </>
     );
 };

--- a/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
+++ b/packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx
@@ -4,6 +4,7 @@ import {
     type UseReferenceManyFieldControllerParams,
 } from './useReferenceManyFieldController';
 import { useTimeout } from '../../util/hooks';
+import { RecordContextProvider } from '../record';
 
 /**
  * Fetch and render the number of records related to the current one
@@ -17,7 +18,14 @@ import { useTimeout } from '../../util/hooks';
  * <ReferenceManyCountBase reference="comments" target="post_id" filter={{ is_published: true }} />
  */
 export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
-    const { loading, error, offline, timeout = 1000, ...rest } = props;
+    const {
+        children,
+        loading,
+        error,
+        offline,
+        timeout = 1000,
+        ...rest
+    } = props;
     const oneSecondHasPassed = useTimeout(timeout);
 
     const {
@@ -37,24 +45,41 @@ export const ReferenceManyCountBase = (props: ReferenceManyCountBaseProps) => {
         isPending && isPaused && offline !== undefined && offline !== false;
     const shouldRenderError =
         !isPending && fetchError && error !== undefined && error !== false;
+    const totalRecord = React.useMemo(() => ({ id: 'count', total }), [total]);
+    const renderChildren =
+        typeof children === 'function' ? children(totalRecord) : children;
 
     return (
         <>
-            {shouldRenderLoading
-                ? oneSecondHasPassed
-                    ? loading
-                    : null
-                : shouldRenderOffline
-                  ? offline
-                  : shouldRenderError
-                    ? error
-                    : total}
+            {shouldRenderLoading ? (
+                oneSecondHasPassed ? (
+                    loading
+                ) : null
+            ) : shouldRenderOffline ? (
+                offline
+            ) : shouldRenderError ? (
+                error
+            ) : children != null ? (
+                <RecordContextProvider value={totalRecord}>
+                    {renderChildren}
+                </RecordContextProvider>
+            ) : (
+                total
+            )}
         </>
     );
 };
 
+export interface ReferenceManyCountRecord {
+    id: string;
+    total: number | undefined;
+}
+
 export interface ReferenceManyCountBaseProps
     extends UseReferenceManyFieldControllerParams {
+    children?:
+        | React.ReactNode
+        | ((record: ReferenceManyCountRecord) => React.ReactNode);
     timeout?: number;
     loading?: React.ReactNode;
     error?: React.ReactNode;

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -4,10 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import {
     Basic,
     ErrorState,
-    LinkWithChildren,
+    LinkWithRender,
     Offline,
     Themed,
-    WithChildren,
+    WithRender,
     WithFilter,
     Wrapper,
 } from './ReferenceManyCount.stories';
@@ -23,13 +23,13 @@ describe('<ReferenceManyCount />', () => {
         await screen.findByText('3');
     });
 
-    it('should render children in a record context containing the total', async () => {
-        render(<WithChildren />);
+    it('should render the result of the render function', async () => {
+        render(<WithRender />);
         await screen.findByText('30,060');
     });
 
-    it('should wrap children in a link when link is true', async () => {
-        render(<LinkWithChildren />);
+    it('should wrap the render function result in a link when link is true', async () => {
+        render(<LinkWithRender />);
         expect(
             await screen.findByRole('link', { name: '30,060' })
         ).toHaveAttribute('href', '/comments?filter={"post_id":1}');

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx
@@ -4,8 +4,10 @@ import { fireEvent, render, screen } from '@testing-library/react';
 import {
     Basic,
     ErrorState,
+    LinkWithChildren,
     Offline,
     Themed,
+    WithChildren,
     WithFilter,
     Wrapper,
 } from './ReferenceManyCount.stories';
@@ -20,6 +22,19 @@ describe('<ReferenceManyCount />', () => {
         render(<Basic />);
         await screen.findByText('3');
     });
+
+    it('should render children in a record context containing the total', async () => {
+        render(<WithChildren />);
+        await screen.findByText('30,060');
+    });
+
+    it('should wrap children in a link when link is true', async () => {
+        render(<LinkWithChildren />);
+        expect(
+            await screen.findByRole('link', { name: '30,060' })
+        ).toHaveAttribute('href', '/comments?filter={"post_id":1}');
+    });
+
     it('should render an error icon when the request fails', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         render(<ErrorState />);

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.stories.tsx
@@ -16,6 +16,7 @@ import { createTheme, ThemeOptions } from '@mui/material';
 
 import { ReferenceManyCount } from './ReferenceManyCount';
 import { defaultLightTheme, ThemeProvider, ThemesContext } from '../theme';
+import { NumberField } from './NumberField';
 
 export default {
     title: 'ra-ui-materialui/fields/ReferenceManyCount',
@@ -84,6 +85,22 @@ export const Basic = () => (
     </Wrapper>
 );
 
+export const WithChildren = () => (
+    <Wrapper
+        dataProvider={{
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [comments.filter(c => c.post_id === 1)[0]],
+                    total: 30060,
+                }),
+        }}
+    >
+        <ReferenceManyCount reference="comments" target="post_id">
+            <NumberField source="total" locales="en-US" />
+        </ReferenceManyCount>
+    </Wrapper>
+);
+
 export const LoadingState = () => (
     <Wrapper dataProvider={{ getManyReference: () => new Promise(() => {}) }}>
         <ReferenceManyCount reference="comments" target="post_id" />
@@ -141,6 +158,22 @@ export const Link = () => (
         }}
     >
         <ReferenceManyCount reference="comments" target="post_id" link />
+    </Wrapper>
+);
+
+export const LinkWithChildren = () => (
+    <Wrapper
+        dataProvider={{
+            getManyReference: () =>
+                Promise.resolve({
+                    data: [comments.filter(c => c.post_id === 1)[0]],
+                    total: 30060,
+                }),
+        }}
+    >
+        <ReferenceManyCount reference="comments" target="post_id" link>
+            <NumberField source="total" locales="en-US" />
+        </ReferenceManyCount>
     </Wrapper>
 );
 

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.stories.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.stories.tsx
@@ -85,7 +85,7 @@ export const Basic = () => (
     </Wrapper>
 );
 
-export const WithChildren = () => (
+export const WithRender = () => (
     <Wrapper
         dataProvider={{
             getManyReference: () =>
@@ -95,9 +95,17 @@ export const WithChildren = () => (
                 }),
         }}
     >
-        <ReferenceManyCount reference="comments" target="post_id">
-            <NumberField source="total" locales="en-US" />
-        </ReferenceManyCount>
+        <ReferenceManyCount
+            reference="comments"
+            target="post_id"
+            render={({ total }) => (
+                <NumberField
+                    record={{ total }}
+                    source="total"
+                    locales="en-US"
+                />
+            )}
+        />
     </Wrapper>
 );
 
@@ -161,7 +169,7 @@ export const Link = () => (
     </Wrapper>
 );
 
-export const LinkWithChildren = () => (
+export const LinkWithRender = () => (
     <Wrapper
         dataProvider={{
             getManyReference: () =>
@@ -171,9 +179,18 @@ export const LinkWithChildren = () => (
                 }),
         }}
     >
-        <ReferenceManyCount reference="comments" target="post_id" link>
-            <NumberField source="total" locales="en-US" />
-        </ReferenceManyCount>
+        <ReferenceManyCount
+            reference="comments"
+            target="post_id"
+            link
+            render={({ total }) => (
+                <NumberField
+                    record={{ total }}
+                    source="total"
+                    locales="en-US"
+                />
+            )}
+        />
     </Wrapper>
 );
 

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
@@ -53,7 +53,7 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
         resource,
         source = 'id',
         offline = defaultOffline,
-        children,
+        render,
         ...rest
     } = props;
     const record = useRecordContext(props);
@@ -67,9 +67,8 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
                 <ErrorIcon color="error" fontSize="small" titleAccess="error" />
             }
             offline={offline}
-        >
-            {children}
-        </ReferenceManyCountBase>
+            render={render}
+        />
     );
     return (
         <StyledTypography

--- a/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
+++ b/packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx
@@ -53,6 +53,7 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
         resource,
         source = 'id',
         offline = defaultOffline,
+        children,
         ...rest
     } = props;
     const record = useRecordContext(props);
@@ -66,7 +67,9 @@ export const ReferenceManyCount = <RecordType extends RaRecord = RaRecord>(
                 <ErrorIcon color="error" fontSize="small" titleAccess="error" />
             }
             offline={offline}
-        />
+        >
+            {children}
+        </ReferenceManyCountBase>
     );
     return (
         <StyledTypography
@@ -106,7 +109,7 @@ const defaultOffline = <Offline variant="inline" />;
 export interface ReferenceManyCountProps<RecordType extends RaRecord = RaRecord>
     extends Omit<FieldProps<RecordType>, 'source'>,
         Omit<ReferenceManyCountBaseProps, 'record'>,
-        Omit<TypographyProps, 'textAlign'> {
+        Omit<TypographyProps, 'children' | 'textAlign'> {
     link?: boolean;
 }
 


### PR DESCRIPTION
## Summary

- Allow `ReferenceManyCountBase` to render custom children using a record context containing `total`
- Forward `ReferenceManyCount` children so fields like `NumberField source=total` can format large counts
- Add stories, tests, and documentation for the new customization path

Fixes #11242

## Tests

- `node .yarn\releases\yarn-4.0.2.cjs test-unit packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx`
- `node .yarn\releases\yarn-4.0.2.cjs exec eslint packages/ra-core/src/controller/field/ReferenceManyCountBase.tsx packages/ra-core/src/controller/field/ReferenceManyCountBase.stories.tsx packages/ra-core/src/controller/field/ReferenceManyCountBase.spec.tsx packages/ra-ui-materialui/src/field/ReferenceManyCount.tsx packages/ra-ui-materialui/src/field/ReferenceManyCount.stories.tsx packages/ra-ui-materialui/src/field/ReferenceManyCount.spec.tsx`
- `node .yarn\releases\yarn-4.0.2.cjs workspace ra-core build`
- `node .yarn\releases\yarn-4.0.2.cjs workspace ra-ui-materialui build`