### PR TITLE
[TypeScript] Fix compilation with react-hook-form 7.72.0

### DIFF
--- a/packages/ra-core/src/form/Form.tsx
+++ b/packages/ra-core/src/form/Form.tsx
@@ -115,7 +115,7 @@ export function Form<RecordType = any>(props: FormProps<RecordType>) {
 export type FormProps<RecordType = any> = FormOwnProps<RecordType> &
     Omit<
         UseFormProps<RecordType extends FieldValues ? RecordType : FieldValues>,
-        'onSubmit'
+        'onSubmit' | 'validate'
     > & {
         validate?: ValidateForm;
         noValidate?: boolean;

--- a/packages/ra-core/src/form/useAugmentedForm.ts
+++ b/packages/ra-core/src/form/useAugmentedForm.ts
@@ -159,7 +159,7 @@ export type UseAugmentedFormProps<RecordType = any> =
             UseFormProps<
                 RecordType extends FieldValues ? RecordType : FieldValues
             >,
-            'onSubmit'
+            'onSubmit' | 'validate'
         > & {
             validate?: ValidateForm;
         };


### PR DESCRIPTION
## Problem

React-hook-form 7.72 introduced form-level validate (https://github.com/react-hook-form/react-hook-form/pull/13195), which conflicts with react-admin's built-in form-level validation.

## Solution

Ignore the new `validate` prop type from react-hook-form

