### PR TITLE
feat: Add emptyText prop to SelectArrayInput

### DIFF
--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -67,6 +67,7 @@ The form value for the source must be an array of the selected values, e.g.
 | `create`          | Optional | `Element`                   | -                   | A React Element to render when users want to create a new choice                                                                       |
 | `createLabel`     | Optional | `string` &#124; `ReactNode` | `ra.action. create` | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
 | `disableValue`    | Optional | `string`                    | 'disabled'          | The custom field name used in `choices` to disable some choices                                                                        |
+| `emptyText`       | Optional | `string` &#124; `ReactNode` | -                   | Text to display when no choice is selected                                                                                             |
 | `InputLabelProps` | Optional | `Object`                    | -                   | Props to pass to the underlying `<InputLabel>` element                                                                                 |
 | `onCreate`        | Optional | `Function`                  | -                   | A function called with the current filter value when users choose to create a new choice.                                              |
 | `options`         | Optional | `Object`                    | -                   | Props to pass to the underlying `<SelectInput>` element                                                                                |
@@ -109,6 +110,25 @@ You can also use an array of objects with different properties for the label and
     { _id: 'u002', label: 'Moderator' },
     { _id: 'u003', label: 'Reviewer' },
 ]} optionValue="_id" optionText="label" />
+```
+
+## `emptyText`
+
+You can customize the text displayed when no choice is selected using the `emptyText` prop:
+
+```jsx
+const channelChoices = [
+    {id: "email", name: "Email"},
+    {id: "push", name: "Push Notification"},
+];
+
+<SelectArrayInput source="channels" choices={channelChoices} emptyText="All Channels" />
+```
+
+The `emptyText` prop also accepts React elements:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} emptyText={<i>All Channels</i>} />
 ```
 
 The choices are translated by default, so you can use translation identifiers as choices:

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -810,4 +810,38 @@ describe('<SelectArrayInput />', () => {
             });
         });
     });
+
+    it('should render the emptyText option correctly', () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput
+                            {...defaultProps}
+                            emptyText="All Channels"
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+        const select = screen.getByDisplayValue('All Channels');
+        expect(select).toBeDefined();
+    });
+
+    it('should render emptyText as React node', () => {
+        render(
+            <AdminContext dataProvider={testDataProvider()}>
+                <ResourceContextProvider value="posts">
+                    <SimpleForm onSubmit={jest.fn()}>
+                        <SelectArrayInput
+                            {...defaultProps}
+                            emptyText={<i>All Channels</i>}
+                        />
+                    </SimpleForm>
+                </ResourceContextProvider>
+            </AdminContext>
+        );
+        const select = screen.getByDisplayValue('All Channels');
+        expect(select).toBeDefined();
+    });
 });

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -291,6 +291,22 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
+export const EmptyText = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="roles"
+            choices={[
+                { id: 'admin', name: 'Admin' },
+                { id: 'u001', name: 'Editor' },
+                { id: 'u002', name: 'Moderator' },
+                { id: 'u003', name: 'Reviewer' },
+            ]}
+            emptyText="All Channels"
+            sx={{ width: 300 }}
+        />
+    </Wrapper>
+);
+
 export const InsideArrayInput = () => (
     <Wrapper>
         <ArrayInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -89,6 +89,14 @@ import { Labeled } from '../Labeled';
  *    { id: 'lifestyle', name: 'myroot.tags.lifestyle' },
  *    { id: 'photography', name: 'myroot.tags.photography' },
  * ];
+ *
+ * You can customize the text displayed when no choice is selected using the `emptyText` prop:
+ * @example
+ * const channelChoices = [
+ *     {id: "email", name: "Email"},
+ *     {id: "push", name: "Push Notification"},
+ * ];
+ * <SelectArrayInput source="channels" choices={channelChoices} emptyText={<i>All Channels</i>} />
  */
 export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     const props = useThemeProps({
@@ -102,6 +110,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
         createLabel,
         createValue,
         disableValue = 'disabled',
+        emptyText,
         format,
         helperText,
         label,
@@ -330,17 +339,27 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     }
                     multiple
                     error={!!fetchError || invalid}
-                    renderValue={(selected: any[]) => (
-                        <div className={SelectArrayInputClasses.chips}>
-                            {(Array.isArray(selected) ? selected : [])
-                                .map(item =>
-                                    (allChoices || []).find(
-                                        // eslint-disable-next-line eqeqeq
-                                        choice => getChoiceValue(choice) == item
-                                    )
+                    renderValue={(selected: any[]) => {
+                        const selectedItems = (Array.isArray(selected) ? selected : [])
+                            .map(item =>
+                                (allChoices || []).find(
+                                    // eslint-disable-next-line eqeqeq
+                                    choice => getChoiceValue(choice) == item
                                 )
-                                .filter(item => !!item)
-                                .map(item => (
+                            )
+                            .filter(item => !!item);
+                        
+                        if (selectedItems.length === 0 && emptyText) {
+                            return typeof emptyText === 'string'
+                                ? emptyText === ''
+                                    ? ' ' // em space, forces the display of an empty line of normal height
+                                    : emptyText
+                                : emptyText;
+                        }
+                        
+                        return (
+                            <div className={SelectArrayInputClasses.chips}>
+                                {selectedItems.map(item => (
                                     <Chip
                                         key={getChoiceValue(item)}
                                         label={renderMenuItemOption(item)}
@@ -348,8 +367,9 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                                         size="small"
                                     />
                                 ))}
-                        </div>
-                    )}
+                            </div>
+                        );
+                    }}
                     disabled={disabled || readOnly}
                     readOnly={readOnly}
                     data-testid="selectArray"
@@ -384,6 +404,7 @@ export type SelectArrayInputProps = ChoicesProps &
         InputLabelProps?: Omit<InputLabelProps, 'htmlFor' | 'id' | 'ref'>;
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
+        emptyText?: React.ReactNode;
     };
 
 const sanitizeRestProps = ({


### PR DESCRIPTION
# Problem
Absence of the emptyText property in the SelectArrayInput component #10454

## Solution
- Add emptyText prop to display custom text when no items selected
- Support both string and ReactNode types for emptyText
- Add comprehensive tests for emptyText functionality
- Add Storybook story demonstrating the feature
- Update documentation with usage examples
- Addresses all feedback from closed PR #10504

## How To Test
- View the updated Storybook story
- Run the new tests
- Check documentation examples

## Additional Checks
- [x] The PR targets 
ext for a feature
- [x] The PR includes unit tests
- [x] The PR includes stories
- [x] The documentation is up to date

Fixes #10454