### PR TITLE
Fix AutocompleteInput with single selection in MUI7

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -783,7 +783,12 @@ If you provided a React element for the optionText prop, you must also provide t
                 }}
                 multiple={multiple}
                 {...(muiMajor >= 7
-                    ? { renderValue: renderChips }
+                    ? // In MUI v7, renderValue replaces renderTags, but it is also
+                      // called in single-selection mode with a non-array value.
+                      // renderChips expects an array, so only use it when multiple.
+                      multiple
+                        ? { renderValue: renderChips }
+                        : {}
                     : { renderTags: renderChips })}
                 noOptionsText={
                     typeof noOptionsText === 'string'


### PR DESCRIPTION
## Problem

The CI workflow fails on the `create-react-admin` end-to-end test (cf https://github.com/marmelab/react-admin/actions/runs/28112984755/job/83248187904)

This reveals a problem in AutocompleteInput, which causes the app to crash on MUI7 when using single selection. 