### PR TITLE
docs: document AutocompleteInput getOptionDisabled

### DIFF
--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -67,6 +67,7 @@ The form value for the source must be the selected value, e.g.
 | `emptyText`                | Optional | `string`                                        | `''`                                       | The text to use for the empty element                                                                                                                                                                               |
 | `emptyValue`               | Optional | `any`                                           | `''`                                       | The value to use for the empty element                                                                                                                                                                              |
 | `filterToQuery`            | Optional | `string` => `Object`                            | `q => ({ q })`                             | How to transform the searchText into a parameter for the data provider                                                                                                                                              |
+| `getOptionDisabled`        | Optional | `Function`                                      | -                                          | A function used to disable individual choices. Signature: `(choice) => boolean`                                                                                                                                      |
 | `isPending`                | Optional | `boolean`                                       | `false`                                    | If `true`, the component will display a loading indicator.                                                                                                                                                          |
 | `inputText`                | Optional | `Function`                                      | `-`                                        | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
 | `matchSuggestion`          | Optional | `Function`                                      | `-`                                        | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
@@ -351,6 +352,35 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
 
 <ReferenceInput label="Author" source="author_id" reference="authors">
     <AutocompleteInput filterToQuery={filterToQuery} />
+</ReferenceInput>
+```
+
+## `getOptionDisabled`
+
+To prevent users from selecting some choices while still displaying them in the suggestion list, pass a `getOptionDisabled` function.
+
+This function receives the choice record and must return a boolean.
+
+```jsx
+<AutocompleteInput
+    source="sender_id"
+    choices={[
+        { id: 1, name: 'John Doe', email: 'john@example.com' },
+        { id: 2, name: 'Jane Doe' },
+    ]}
+    helperText="Only contacts with an email address can be selected"
+    getOptionDisabled={choice => !choice.email}
+/>
+```
+
+You can also use `getOptionDisabled` inside a [`<ReferenceInput>`](./ReferenceInput.md):
+
+```jsx
+<ReferenceInput source="sender_id" reference="staff">
+    <AutocompleteInput
+        helperText="Only staff members with an email address can be selected"
+        getOptionDisabled={record => !record.email}
+    />
 </ReferenceInput>
 ```
 


### PR DESCRIPTION
## Problem

`<AutocompleteInput>` supports `getOptionDisabled`, but this prop is not documented. This makes it hard to discover how to keep unavailable choices visible while preventing users from selecting them.

Closes #11299.

## Solution

Document `getOptionDisabled` in the `<AutocompleteInput>` props table and add examples for both direct `choices` usage and usage inside `<ReferenceInput>`.

## How To Test

- Read `docs/AutocompleteInput.md` and confirm the new `getOptionDisabled` section explains the prop and shows examples.
- Ran `git diff --check`.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [ ] The PR includes **unit tests** (if not possible, describe why)
  - Not included: documentation-only change.
- [ ] The PR includes one or several **stories** (if not possible, describe why)
  - Not included: documentation-only change.
- [x] The **documentation** is up to date