### PR TITLE
Save InPlaceEditor changes when focus moves outside

### DIFF
--- a/packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.spec.tsx
@@ -1,7 +1,17 @@
 import * as React from 'react';
 import { render, screen, fireEvent } from '@testing-library/react';
 
-import { Basic } from './InPlaceEditor.stories';
+import { Basic, CancelOnBlur, Editor } from './InPlaceEditor.stories';
+
+const DismissibleBasic = () => {
+    const [isVisible, setIsVisible] = React.useState(true);
+    return (
+        <>
+            {isVisible ? <Basic delay={0} /> : null}
+            <button onClick={() => setIsVisible(false)}>Next</button>
+        </>
+    );
+};
 
 describe('InPlaceEditor', () => {
     it('should render the field value on mount', async () => {
@@ -23,6 +33,41 @@ describe('InPlaceEditor', () => {
         fireEvent.blur(input);
         await screen.findByText('Jane Doe');
     });
+    it('should save when focus moves outside the editor', async () => {
+        render(
+            <>
+                <Basic delay={0} />
+                <button>Next</button>
+            </>
+        );
+        const value = await screen.findByText('John Doe');
+        value.click();
+        const input = await screen.findByDisplayValue('John Doe');
+        input.focus();
+        fireEvent.change(input, { target: { value: 'Jane Doe' } });
+        const nextButton = screen.getByRole('button', { name: 'Next' });
+        nextButton.focus();
+        await screen.findByText('Jane Doe');
+    });
+    it('should save before an outside action unmounts the editor', async () => {
+        render(<DismissibleBasic />);
+        const value = await screen.findByText('John Doe');
+        value.click();
+        const input = await screen.findByDisplayValue('John Doe');
+        input.focus();
+        fireEvent.change(input, { target: { value: 'Jane Doe' } });
+        const form = input.closest('form');
+        if (!form) {
+            throw new Error('Could not find the InPlaceEditor form');
+        }
+        const handleSubmit = jest.fn();
+        form.addEventListener('submit', handleSubmit);
+        const nextButton = screen.getByRole('button', { name: 'Next' });
+        nextButton.focus();
+        fireEvent.click(nextButton);
+        expect(screen.queryByDisplayValue('Jane Doe')).toBeNull();
+        expect(handleSubmit).toHaveBeenCalledTimes(1);
+    });
     it('should revert to the previous version on error', async () => {
         jest.spyOn(console, 'error').mockImplementation(() => {});
         render(<Basic delay={0} updateFails />);
@@ -33,6 +78,41 @@ describe('InPlaceEditor', () => {
         fireEvent.blur(input);
         await screen.findByText('Jane Doe');
         await screen.findByText('John Doe');
+    });
+    describe('cancelOnBlur', () => {
+        it('should cancel when focus moves outside the editor', async () => {
+            render(
+                <>
+                    <CancelOnBlur />
+                    <button>Next</button>
+                </>
+            );
+            const value = await screen.findByText('John Doe');
+            value.click();
+            const input = await screen.findByDisplayValue('John Doe');
+            input.focus();
+            fireEvent.change(input, { target: { value: 'Jane Doe' } });
+            const nextButton = screen.getByRole('button', { name: 'Next' });
+            nextButton.focus();
+            await screen.findByText('John Doe');
+        });
+    });
+    describe('editor', () => {
+        it('should keep editing when focus moves to a portaled control', async () => {
+            render(<Editor />);
+            const value = await screen.findByText('Customer');
+            value.click();
+            await screen.findByRole('listbox', undefined, {
+                timeout: 1000,
+            });
+            const selectedOption = await screen.findByRole(
+                'option',
+                { name: 'Customer' },
+                { timeout: 1000 }
+            );
+            expect(document.activeElement).toBe(selectedOption);
+            await screen.findByRole('combobox', { hidden: true });
+        });
     });
     describe('notifyOnSuccess', () => {
         it('should show a notification on success', async () => {
@@ -52,6 +132,17 @@ describe('InPlaceEditor', () => {
             value.click();
             await screen.findByLabelText('Save');
             await screen.findByLabelText('Cancel');
+        });
+        it('should keep editing when focus moves to an action button', async () => {
+            render(<Basic delay={0} showButtons />);
+            const value = await screen.findByText('John Doe');
+            value.click();
+            const input = await screen.findByDisplayValue('John Doe');
+            input.focus();
+            fireEvent.change(input, { target: { value: 'Jane Doe' } });
+            const saveButton = await screen.findByLabelText('Save');
+            saveButton.focus();
+            await screen.findByDisplayValue('Jane Doe');
         });
     });
 });

--- a/packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.tsx
+++ b/packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.tsx
@@ -6,6 +6,7 @@ import {
     useResourceContext,
     useTranslate,
     useUpdate,
+    useEvent,
     Form,
     RecordContextProvider,
     type UseUpdateOptions,
@@ -101,6 +102,8 @@ export const InPlaceEditor = <
     }
 
     const submitButtonRef = useRef<HTMLButtonElement>(null);
+    const pendingBlurRef = useRef(false);
+    const focusDocumentRef = useRef<Document | null>(null);
 
     const [state, dispatch] = useReducer<
         (
@@ -195,10 +198,7 @@ export const InPlaceEditor = <
         }
     };
 
-    const handleBlur = (event: React.FocusEvent) => {
-        if (event.relatedTarget) {
-            return;
-        }
+    const handleBlurAway = useEvent(() => {
         if (cancelOnBlur) {
             dispatch({ type: 'cancel' });
             return;
@@ -206,8 +206,47 @@ export const InPlaceEditor = <
         if (state.state === 'editing') {
             // trigger the parent form submit
             // to save the changes
-            (submitButtonRef.current as HTMLButtonElement).click();
+            submitButtonRef.current?.click();
         }
+    });
+    const handleDocumentFocusIn = useEvent(() => {
+        focusDocumentRef.current = null;
+        if (!pendingBlurRef.current) {
+            return;
+        }
+        pendingBlurRef.current = false;
+        handleBlurAway();
+    });
+    React.useEffect(
+        () => () => {
+            focusDocumentRef.current?.removeEventListener(
+                'focusin',
+                handleDocumentFocusIn
+            );
+        },
+        [handleDocumentFocusIn]
+    );
+    const handleBlur = (event: React.FocusEvent) => {
+        if (!event.relatedTarget) {
+            handleBlurAway();
+            return;
+        }
+        pendingBlurRef.current = true;
+        // React focus events from portals bubble through their component tree
+        // before reaching document, so handleFocus can cancel internal moves.
+        // External moves are handled here before the destination's click event.
+        const ownerDocument = event.currentTarget.ownerDocument;
+        focusDocumentRef.current?.removeEventListener(
+            'focusin',
+            handleDocumentFocusIn
+        );
+        focusDocumentRef.current = ownerDocument;
+        ownerDocument.addEventListener('focusin', handleDocumentFocusIn, {
+            once: true,
+        });
+    };
+    const handleFocus = () => {
+        pendingBlurRef.current = false;
     };
 
     const renderContent = () => {
@@ -227,6 +266,7 @@ export const InPlaceEditor = <
                         <Box
                             onKeyDown={handleKeyDown}
                             onBlur={handleBlur}
+                            onFocus={handleFocus}
                             className={InPlaceEditorClasses.editing}
                         >
                             {editor}


### PR DESCRIPTION
## Problem

`InPlaceEditor` returned early for every blur event with a non-null `relatedTarget`. As a result, moving focus to another button, link, or input left the editor open and neither saved nor canceled the change.

Fixes #11303.

## Solution

- Track a pending blur when focus is moving to another element.
- Resolve it from the destination document's bubbling `focusin` event, before the destination's click handler runs.
- Cancel the pending blur when React reports focus still inside the editor's logical subtree. This includes controls rendered through a React portal, such as the documented `SelectInput` editor.
- Keep the existing synchronous behavior when the blur has no `relatedTarget`.

## Impact

Tabbing or clicking from an `InPlaceEditor` to an outside focusable control now saves by default, or cancels when `cancelOnBlur` is enabled. Focus moves to built-in action buttons and portalled editor controls continue to stay in edit mode.

## Verification

- `corepack yarn test-unit --runTestsByPath packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.spec.tsx --runInBand`
- `corepack yarn eslint packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.tsx packages/ra-ui-materialui/src/input/InPlaceEditor/InPlaceEditor.spec.tsx`
- `corepack yarn workspace ra-core build`
- `corepack yarn workspace ra-ui-materialui build`
