### PR TITLE
Fix `<RichTextInput>` crash when the editor is recreated

### DIFF
--- a/packages/ra-input-rich-text/src/RichTextInput.spec.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.spec.tsx
@@ -1,7 +1,8 @@
 import * as React from 'react';
 import expect from 'expect';
-import { render, waitFor } from '@testing-library/react';
-import { Basic } from './RichTextInput.stories';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { Basic, EditorRecreation } from './RichTextInput.stories';
 
 describe('<RichTextInput />', () => {
     it('should update its content when fields value changes and add a trailing break to it', async () => {
@@ -20,6 +21,24 @@ describe('<RichTextInput />', () => {
         await waitFor(() => {
             expect(container.querySelector('.ProseMirror')?.innerHTML).toEqual(
                 '<h1>Goodbye world!</h1><p><br class="ProseMirror-trailingBreak"></p>'
+            );
+        });
+    });
+
+    it('should update its content when the editor is recreated while the field value changes', async () => {
+        const { container } = render(<EditorRecreation />);
+
+        await waitFor(() => {
+            expect(container.querySelector('.ProseMirror')?.innerHTML).toEqual(
+                '<p>This post is a draft, you can edit it.</p>'
+            );
+        });
+
+        await userEvent.click(screen.getByText('Switch post'));
+
+        await waitFor(() => {
+            expect(container.querySelector('.ProseMirror')?.innerHTML).toEqual(
+                '<p>This post is published, it is read-only.</p>'
             );
         });
     });

--- a/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.stories.tsx
@@ -17,7 +17,7 @@ import {
     Toolbar as RAToolbar,
     SaveButton,
 } from 'ra-ui-materialui';
-import { useWatch } from 'react-hook-form';
+import { useFormContext, useWatch } from 'react-hook-form';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Routes, Route } from 'react-router-dom';
 import Mention from '@tiptap/extension-mention';
@@ -111,6 +111,65 @@ export const ReadOnly = (props: Partial<SimpleFormProps>) => (
         </ResourceContextProvider>
     </AdminContext>
 );
+
+const postsToSwitch = [
+    { body: '<p>This post is a draft, you can edit it.</p>', readOnly: false },
+    { body: '<p>This post is published, it is read-only.</p>', readOnly: true },
+];
+
+const SwitchPostButton = ({
+    postIndex,
+    onSwitch,
+}: {
+    postIndex: number;
+    onSwitch: (index: number) => void;
+}) => {
+    const { setValue } = useFormContext();
+    return (
+        <Button
+            onClick={() => {
+                const nextIndex = (postIndex + 1) % postsToSwitch.length;
+                setValue('body', postsToSwitch[nextIndex].body);
+                onSwitch(nextIndex);
+            }}
+        >
+            Switch post
+        </Button>
+    );
+};
+
+/**
+ * Changing the value and the readOnly prop at the same time recreates the editor
+ * while the content sync effect still references the previous (destroyed) one.
+ * Clicking on "Switch post" used to throw
+ * "Cannot read properties of null (reading 'commands')".
+ */
+export const EditorRecreation = (props: Partial<SimpleFormProps>) => {
+    const [postIndex, setPostIndex] = React.useState(0);
+    return (
+        <AdminContext i18nProvider={i18nProvider}>
+            <ResourceContextProvider value="posts">
+                <Card>
+                    <SimpleForm
+                        defaultValues={{ body: postsToSwitch[0].body }}
+                        onSubmit={() => {}}
+                        {...props}
+                    >
+                        <SwitchPostButton
+                            postIndex={postIndex}
+                            onSwitch={setPostIndex}
+                        />
+                        <RichTextInput
+                            source="body"
+                            readOnly={postsToSwitch[postIndex].readOnly}
+                        />
+                        <FormInspector />
+                    </SimpleForm>
+                </Card>
+            </ResourceContextProvider>
+        </AdminContext>
+    );
+};
 
 export const Small = (props: Partial<SimpleFormProps>) => (
     <AdminContext i18nProvider={i18nProvider}>

--- a/packages/ra-input-rich-text/src/RichTextInput.tsx
+++ b/packages/ra-input-rich-text/src/RichTextInput.tsx
@@ -114,7 +114,12 @@ export const RichTextInput = (props: RichTextInputProps) => {
     const { error, invalid, isTouched } = fieldState;
 
     useEffect(() => {
-        if (!editor) return;
+        // Tiptap v3's Editor.destroy() sets commandManager to null, and the
+        // `commands` getter dereferences it. When the editor is recreated (e.g.
+        // readOnly/disabled/editorOptions/id change), this passive effect can run
+        // against the just-destroyed instance, throwing "Cannot read properties of
+        // null (reading 'commands')". Bail out on destroyed editors as well.
+        if (!editor || editor.isDestroyed) return;
 
         const { from, to } = editor.state.selection;
 


### PR DESCRIPTION
## Problem

Under tiptap v3, `<RichTextInput>` can crash with:

```
TypeError: Cannot read properties of null (reading 'commands')
    at get commands (@tiptap/core)
    at RichTextInput (content-sync useEffect)
    at commitHookEffectListMount (react-dom)
```

It happens when the editor is **recreated** — e.g. toggling `readOnly`/`disabled`, or changing `editorOptions`/`id` — while a record/value change is in flight. In our app it reproduces reliably when switching between records/replies (which flips `readOnly` and changes the content at the same time).

## Root cause

tiptap v3's `Editor.destroy()` sets `this.commandManager = null`, and the `commands` getter returns `this.commandManager.commands`. The content-sync effect guards only `if (!editor) return`, so when `useEditor` recreates the editor, the old (now destroyed) instance can still be referenced by this passive effect, which then calls `editor.commands.setContent(...)` on it → dereference of a null `commandManager`.

```ts
useEffect(() => {
    if (!editor) return; // truthy but destroyed slips through
    const { from, to } = editor.state.selection;
    editor.commands.setContent(field.value, { ... }); // 💥 commandManager is null
    editor.commands.setTextSelection({ from, to });
}, [editor, field.value]);
```

## Fix

Also bail out when the editor is destroyed:

```ts
if (!editor || editor.isDestroyed) return;
```

`editor.isDestroyed` returns `true` once `destroy()` has run (it reads `editorView?.isDestroyed ?? true`), and `destroy()` nulls `commandManager` in the same call, so this reliably prevents the dereference. It mirrors the existing `!editor` guard and is a no-op in the normal path.

## Notes

- Reproduced on `ra-input-rich-text@5.15.1` with `@tiptap/*@3` (package declares `@tiptap/* ^3.20.4`).
- The crash is timing-dependent (editor recreation + passive-effect ordering), so I didn't add a deterministic jsdom test — happy to add one if you can point me at the preferred way to simulate editor recreation in the existing test harness.
