### PR TITLE
Fix useListController resets the persisted page while the list query is disabled during the auth check

### DIFF
--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -160,7 +160,7 @@ describe('useInfiniteListController', () => {
             });
         });
 
-        it('should reset page when enabled is set to false', async () => {
+        it('should not crash when the query is disabled and data is undefined', async () => {
             const children = jest.fn().mockReturnValue(<span>children</span>);
             const dataProvider = testDataProvider({
                 getList: () => Promise.resolve({ data: [], total: 0 }),
@@ -176,18 +176,81 @@ describe('useInfiniteListController', () => {
                 </CoreAdminContext>
             );
 
-            act(() => {
-                // @ts-ignore
-                children.mock.calls.at(-1)[0].setPage(3);
-            });
-
             await waitFor(() => {
-                expect(children).toHaveBeenCalledWith(
+                const lastCall = children.mock.calls.at(-1)?.[0];
+                expect(lastCall.isPending).toBe(true);
+                expect(lastCall.data).toBeUndefined();
+            });
+        });
+
+        it('should not reset a persisted page while the query is disabled during the auth check', async () => {
+            let resolveAuthCheck: () => void;
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn(
+                    () =>
+                        new Promise(resolve => {
+                            resolveAuthCheck = resolve;
+                        })
+                ),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+            };
+            const getList = jest.fn(() =>
+                Promise.resolve({
+                    data: [{ id: 1, title: 'A post' }],
+                    total: 100,
+                })
+            );
+            const dataProvider = testDataProvider({ getList });
+            // params persisted with page 3, e.g. from a previous visit or reload
+            const store = memoryStore({
+                'posts.listParams': {
+                    page: 3,
+                    perPage: 10,
+                    sort: 'id',
+                    order: 'ASC',
+                    filter: {},
+                    displayedFilters: {},
+                },
+            });
+            const props = { ...defaultProps, children: jest.fn() };
+            render(
+                <CoreAdminContext
+                    authProvider={authProvider}
+                    dataProvider={dataProvider}
+                    store={store}
+                >
+                    <InfiniteListController {...props} resource="posts" />
+                </CoreAdminContext>
+            );
+
+            // the list query stays disabled while checkAuth is pending
+            await waitFor(() => {
+                expect(authProvider.checkAuth).toHaveBeenCalled();
+            });
+            expect(getList).not.toHaveBeenCalled();
+
+            resolveAuthCheck!();
+
+            // once enabled, the data provider is queried for the persisted
+            // page 3, not page 1
+            await waitFor(() => {
+                expect(getList).toHaveBeenCalledWith(
+                    'posts',
                     expect.objectContaining({
-                        page: 1,
+                        pagination: { page: 3, perPage: 10 },
                     })
                 );
             });
+            expect(getList).not.toHaveBeenCalledWith(
+                'posts',
+                expect.objectContaining({
+                    pagination: { page: 1, perPage: 10 },
+                })
+            );
+            expect(store.getItem('posts.listParams').page).toBe(3);
         });
     });
 

--- a/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.spec.tsx
@@ -222,7 +222,12 @@ describe('useInfiniteListController', () => {
                     dataProvider={dataProvider}
                     store={store}
                 >
-                    <InfiniteListController {...props} resource="posts" />
+                    <InfiniteListController
+                        {...props}
+                        resource="posts"
+                        disableSyncWithLocation
+                        storeKey="posts.listParams"
+                    />
                 </CoreAdminContext>
             );
 

--- a/packages/ra-core/src/controller/list/useInfiniteListController.ts
+++ b/packages/ra-core/src/controller/list/useInfiniteListController.ts
@@ -162,6 +162,10 @@ export const useInfiniteListController = <
 
     // change page if there is no data
     useEffect(() => {
+        // While the query is disabled (e.g. during the auth check) or loading
+        // for the first time, data is null but that doesn't mean the page is
+        // empty, so don't reset it.
+        if (isPending) return;
         if (
             query.page <= 0 ||
             (!isFetching &&
@@ -181,7 +185,15 @@ export const useInfiniteListController = <
             // It occurs when deleting the last element of the last page
             queryModifiers.setPage(totalPages);
         }
-    }, [isFetching, query.page, query.perPage, data, queryModifiers, total]);
+    }, [
+        isPending,
+        isFetching,
+        query.page,
+        query.perPage,
+        data,
+        queryModifiers,
+        total,
+    ]);
 
     const currentSort = useMemo(
         () => ({

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -143,7 +143,12 @@ describe('useListController', () => {
                     dataProvider={dataProvider}
                     store={store}
                 >
-                    <ListController {...props} resource="posts" />
+                    <ListController
+                        {...props}
+                        resource="posts"
+                        disableSyncWithLocation
+                        storeKey="posts.listParams"
+                    />
                 </CoreAdminContext>
             );
 

--- a/packages/ra-core/src/controller/list/useListController.spec.tsx
+++ b/packages/ra-core/src/controller/list/useListController.spec.tsx
@@ -80,7 +80,7 @@ describe('useListController', () => {
             });
         });
 
-        it('should reset page when enabled is set to false', async () => {
+        it('should not crash when the query is disabled and data is undefined', async () => {
             const children = jest.fn().mockReturnValue(<span>children</span>);
             const dataProvider = testDataProvider({
                 getList: () => Promise.resolve({ data: [], total: 0 }),
@@ -97,18 +97,81 @@ describe('useListController', () => {
                 </CoreAdminContext>
             );
 
-            act(() => {
-                // @ts-ignore
-                children.mock.calls.at(-1)[0].setPage(3);
-            });
-
             await waitFor(() => {
-                expect(children).toHaveBeenCalledWith(
+                const lastCall = children.mock.calls.at(-1)?.[0];
+                expect(lastCall.isPending).toBe(true);
+                expect(lastCall.data).toBeUndefined();
+            });
+        });
+
+        it('should not reset a persisted page while the query is disabled during the auth check', async () => {
+            let resolveAuthCheck: () => void;
+            const authProvider: AuthProvider = {
+                checkAuth: jest.fn(
+                    () =>
+                        new Promise(resolve => {
+                            resolveAuthCheck = resolve;
+                        })
+                ),
+                login: () => Promise.resolve(),
+                logout: () => Promise.resolve(),
+                checkError: () => Promise.resolve(),
+                getPermissions: () => Promise.resolve(),
+            };
+            const getList = jest.fn(() =>
+                Promise.resolve({
+                    data: [{ id: 1, title: 'A post' }],
+                    total: 100,
+                })
+            );
+            const dataProvider = testDataProvider({ getList });
+            // params persisted with page 3, e.g. from a previous visit or reload
+            const store = memoryStore({
+                'posts.listParams': {
+                    page: 3,
+                    perPage: 10,
+                    sort: 'id',
+                    order: 'ASC',
+                    filter: {},
+                    displayedFilters: {},
+                },
+            });
+            const props = { ...defaultProps, children: jest.fn() };
+            render(
+                <CoreAdminContext
+                    authProvider={authProvider}
+                    dataProvider={dataProvider}
+                    store={store}
+                >
+                    <ListController {...props} resource="posts" />
+                </CoreAdminContext>
+            );
+
+            // the list query stays disabled while checkAuth is pending
+            await waitFor(() => {
+                expect(authProvider.checkAuth).toHaveBeenCalled();
+            });
+            expect(getList).not.toHaveBeenCalled();
+
+            resolveAuthCheck!();
+
+            // once enabled, the data provider is queried for the persisted
+            // page 3, not page 1
+            await waitFor(() => {
+                expect(getList).toHaveBeenCalledWith(
+                    'posts',
                     expect.objectContaining({
-                        page: 1,
+                        pagination: { page: 3, perPage: 10 },
                     })
                 );
             });
+            expect(getList).not.toHaveBeenCalledWith(
+                'posts',
+                expect.objectContaining({
+                    pagination: { page: 1, perPage: 10 },
+                })
+            );
+            expect(store.getItem('posts.listParams').page).toBe(3);
         });
     });
 

--- a/packages/ra-core/src/controller/list/useListController.ts
+++ b/packages/ra-core/src/controller/list/useListController.ts
@@ -162,6 +162,10 @@ export const useListController = <
 
     // change page if there is no data
     useEffect(() => {
+        // While the query is disabled (e.g. during the auth check) or loading
+        // for the first time, data is null but that doesn't mean the page is
+        // empty, so don't reset it.
+        if (isPending) return;
         if (
             query.page <= 0 ||
             (!isFetching &&
@@ -181,7 +185,15 @@ export const useListController = <
             // It occurs when deleting the last element of the last page
             queryModifiers.setPage(totalPages);
         }
-    }, [isFetching, query.page, query.perPage, data, queryModifiers, total]);
+    }, [
+        isPending,
+        isFetching,
+        query.page,
+        query.perPage,
+        data,
+        queryModifiers,
+        total,
+    ]);
 
     const currentSort = useMemo(
         () => ({


### PR DESCRIPTION
## Problem

When list params are persisted (in the store or in the URL) with `page > 1`, remounting the list (e.g. a full page reload, or first navigation into the app) should restore that page. This worked up to react-admin 5.2.x.

On apps with an `authProvider`, the persisted page is reset to 1 on every cold mount. On the network you typically see a request for the stored page (e.g. page 3) immediately aborted/superseded by a request for page 1, and the store/URL is overwritten with `page: 1`.

## Root cause analysis

Since 5.3.0, `useListController` gates the `useGetList` query on the auth check:

```ts
// useListController.ts
enabled:
    (!isPendingAuthenticated && !isPendingCanAccess) ||
    disableAuthentication,
```

On a cold mount (fresh QueryClient), `useAuthenticated()`'s query is `isPending: true` for at least one render, so the list query starts **disabled**. For a disabled query, TanStack Query reports `isFetching: false` and `data: undefined`.

The page-reset effect (unchanged since v4) then fires on the very first commit:

```ts
// useListController.ts
useEffect(() => {
    if (
        query.page <= 0 ||
        (!isFetching &&
            query.page > 1 &&
            (data == null || data?.length === 0))
    ) {
        // Query for a page that doesn't exist, set page to 1
        queryModifiers.setPage(1);
        return;
    }
    ...
}, [isFetching, query.page, query.perPage, data, queryModifiers, total]);
```

`!isFetching` is true (query disabled), `data == null` is true (nothing fetched yet), `query.page > 1` is true (restored from store/URL) → `setPage(1)` is dispatched before the data provider was ever called.

The dispatch is deferred by `setTimeout(0)` inside `changeParams` (useListParams), while `checkAuth` usually resolves in a microtask — that's why you often see the request for the stored page fire first and then get replaced by a page-1 request.

The same reset does **not** happen while navigating inside the app because the `['auth', 'checkAuth']` query is then already cached (`isPending: false`), so the list query is enabled from its first render and `isFetching` guards the effect. This makes the bug look intermittent (only reproduces on reload / first mount).

## Steps to reproduce

1. Configure an `Admin` with any `authProvider` whose `checkAuth` resolves asynchronously (any real-world implementation does):

```tsx
const authProvider = {
    checkAuth: () => new Promise<void>(resolve => setTimeout(resolve, 200)),
    checkError: () => Promise.resolve(),
    login: () => Promise.resolve(),
    logout: () => Promise.resolve(),
};

<Admin dataProvider={dataProvider} authProvider={authProvider}>
    <Resource name="posts" list={PostList} />
</Admin>
```

2. Open the list, navigate to page 3.
3. Reload the browser (F5).
4. The list shows page 1; the stored params (and `?page=3` in the URL, when location sync is on) are overwritten with `page: 1`.

Also reproducible with `disableSyncWithLocation` + `storeKey` (params persisted in `localStorageStore`): the stored page is wiped on every reload.

## Solution

The effect should not treat "query disabled / not yet started" as "page is empty". Guarding with `isPending` (already returned by `useGetList`) is enough:

```ts
useEffect(() => {
    if (isPending) return; // query disabled or first fetch not finished
    if (
        query.page <= 0 ||
        (!isFetching &&
            query.page > 1 &&
            (data == null || data?.length === 0))
    ) {
        queryModifiers.setPage(1);
        return;
    }
    ...
```

Closes #11297

