### PR TITLE
Fix some MUI Icons changed appearance

### DIFF
--- a/docs/FilterList.md
+++ b/docs/FilterList.md
@@ -27,7 +27,7 @@ For instance, here is a filter sidebar for a post list, allowing users to filter
 ```jsx
 import { SavedQueriesList, FilterLiveSearch, FilterList, FilterListItem } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
-import MailIcon from '@mui/icons-material/MailOutline';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import CategoryIcon from '@mui/icons-material/LocalOffer';
 
 export const PostFilterSidebar = () => (
@@ -288,7 +288,7 @@ If you want to add a simple text input to the sidebar, you can use the [`<Filter
 ```jsx
 import { FilterLiveSearch, FilterList, FilterListItem } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
-import MailIcon from '@mui/icons-material/MailOutline';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 
 export const PostFilterSidebar = () => (
     <Card sx={{ order: -1, mr: 2, mt: 6, width: 250, height: 'fit-content' }}>

--- a/docs/FilteringTutorial.md
+++ b/docs/FilteringTutorial.md
@@ -155,7 +155,7 @@ Here is an example FilterList sidebar:
 ```jsx
 import { SavedQueriesList, FilterLiveSearch, FilterList, FilterListItem } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
-import MailIcon from '@mui/icons-material/MailOutline';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import CategoryIcon from '@mui/icons-material/LocalOffer';
 
 export const PostFilterSidebar = () => (

--- a/docs/List.md
+++ b/docs/List.md
@@ -238,7 +238,7 @@ The `aside` prop is also the preferred way to add a [Filter Sidebar](./Filtering
 // in src/PostFilterSidebar.js
 import { SavedQueriesList, FilterLiveSearch, FilterList, FilterListItem } from 'react-admin';
 import { Card, CardContent } from '@mui/material';
-import MailIcon from '@mui/icons-material/MailOutline';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import CategoryIcon from '@mui/icons-material/LocalOffer';
 
 export const PostFilterSidebar = () => (

--- a/examples/demo/src/visitors/VisitorListAside.tsx
+++ b/examples/demo/src/visitors/VisitorListAside.tsx
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { Card, CardContent } from '@mui/material';
 import AccessTimeIcon from '@mui/icons-material/AccessTime';
 import MonetizationOnIcon from '@mui/icons-material/MonetizationOnOutlined';
-import MailIcon from '@mui/icons-material/MailOutline';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import LocalOfferIcon from '@mui/icons-material/LocalOfferOutlined';
 import {
     FilterList,

--- a/packages/ra-core/src/form/FilterLiveForm.tsx
+++ b/packages/ra-core/src/form/FilterLiveForm.tsx
@@ -29,7 +29,7 @@ import { useListContext } from '../controller/list/useListContext';
  * at other places to create your own filter UI.
  *
  * @example
- * import MailIcon from '@mui/icons-material/MailOutlined';
+ * import MailIcon from '@mui/icons-material/MailOutlineOutlined';
  * import TitleIcon from '@mui/icons-material/Title';
  * import { Card, CardContent } from '@mui/material';
  * import * as React from 'react';

--- a/packages/ra-ui-materialui/src/input/ArrayInput/AddItemButton.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/AddItemButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import AddIcon from '@mui/icons-material/AddCircleOutlined';
+import AddIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 import clsx from 'clsx';
 import { useSimpleFormIterator } from 'ra-core';
 import { IconButtonWithTooltip, ButtonProps } from '../../button';

--- a/packages/ra-ui-materialui/src/input/ArrayInput/RemoveItemButton.tsx
+++ b/packages/ra-ui-materialui/src/input/ArrayInput/RemoveItemButton.tsx
@@ -1,5 +1,5 @@
 import * as React from 'react';
-import CloseIcon from '@mui/icons-material/RemoveCircleOutlined';
+import CloseIcon from '@mui/icons-material/RemoveCircleOutlineOutlined';
 import clsx from 'clsx';
 import { useSimpleFormIterator, useSimpleFormIteratorItem } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/input/FileInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/FileInput.stories.tsx
@@ -9,7 +9,7 @@ import { FileInput } from './FileInput';
 import { FileField } from '../field';
 import { required } from 'ra-core';
 import { FormInspector } from './common';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined';
 
 export default { title: 'ra-ui-materialui/input/FileInput' };
 

--- a/packages/ra-ui-materialui/src/input/ImageInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/ImageInput.stories.tsx
@@ -9,7 +9,7 @@ import { ImageInput } from './ImageInput';
 import { ImageField } from '../field';
 import { required } from 'ra-core';
 import { FormInspector } from './common';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined';
 
 export default { title: 'ra-ui-materialui/input/ImageInput' };
 

--- a/packages/ra-ui-materialui/src/layout/Confirm.tsx
+++ b/packages/ra-ui-materialui/src/layout/Confirm.tsx
@@ -15,7 +15,7 @@ import {
     useThemeProps,
 } from '@mui/material/styles';
 import ActionCheck from '@mui/icons-material/CheckCircle';
-import AlertError from '@mui/icons-material/ErrorOutlined';
+import AlertError from '@mui/icons-material/ErrorOutlineOutlined';
 import clsx from 'clsx';
 import { useTranslate } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/list/filter/AddSavedQueryIconButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/AddSavedQueryIconButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { IconButton, IconButtonProps } from '@mui/material';
-import AddIcon from '@mui/icons-material/AddCircleOutlined';
+import AddIcon from '@mui/icons-material/AddCircleOutlineOutlined';
 import { useTranslate } from 'ra-core';
 
 import { AddSavedQueryDialog } from './AddSavedQueryDialog';

--- a/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterFormInput.tsx
@@ -5,7 +5,7 @@ import {
     useThemeProps,
 } from '@mui/material/styles';
 import { IconButton } from '@mui/material';
-import ActionHide from '@mui/icons-material/RemoveCircleOutlined';
+import ActionHide from '@mui/icons-material/RemoveCircleOutlineOutlined';
 import clsx from 'clsx';
 import { useResourceContext, useTranslate } from 'ra-core';
 

--- a/packages/ra-ui-materialui/src/list/filter/FilterList.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterList.stories.tsx
@@ -7,7 +7,7 @@ import {
 } from 'ra-core';
 import fakeRestDataProvider from 'ra-data-fakerest';
 import { Box, Typography, Card, CardContent } from '@mui/material';
-import MailIcon from '@mui/icons-material/MailOutlined';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import BiotechIcon from '@mui/icons-material/Biotech';
 import NewspaperIcon from '@mui/icons-material/Newspaper';
 import LocalOfferIcon from '@mui/icons-material/LocalOffer';

--- a/packages/ra-ui-materialui/src/list/filter/FilterList.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterList.tsx
@@ -17,7 +17,7 @@ import { FilterListSection } from './FilterListSection';
  *
  * import * as React from 'react';
  * import { Card, CardContent } from '@mui/material';
- * import MailIcon from '@mui/icons-material/MailOutlined';
+ * import MailIcon from '@mui/icons-material/MailOutlineOutlined';
  * import { FilterList, FilterListItem } from 'react-admin';
  *
  * const FilterSidebar = () => (

--- a/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListItem.tsx
@@ -42,7 +42,7 @@ const arePropsEqual = (prevProps, nextProps) =>
  *
  * import * as React from 'react';
  * import { Card, CardContent } from '@mui/material';
- * import MailIcon from '@mui/icons-material/MailOutlined';
+ * import MailIcon from '@mui/icons-material/MailOutlineOutlined';
  * import { FilterList, FilterListItem } from 'react-admin';
  *
  * const FilterSidebar = () => (

--- a/packages/ra-ui-materialui/src/list/filter/FilterListSection.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListSection.stories.tsx
@@ -1,5 +1,5 @@
 import CategoryIcon from '@mui/icons-material/LocalOffer';
-import MailIcon from '@mui/icons-material/MailOutlined';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import { Card, CardContent, List, ListItem, Typography } from '@mui/material';
 import * as React from 'react';
 

--- a/packages/ra-ui-materialui/src/list/filter/FilterListSection.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterListSection.tsx
@@ -14,7 +14,7 @@ import { useTranslate } from 'ra-core';
  * own components look nicer alongside a filter list.
  *
  * @example
- * import MailIcon from '@mui/icons-material/MailOutlined';
+ * import MailIcon from '@mui/icons-material/MailOutlineOutlined';
  * import TitleIcon from '@mui/icons-material/Title';
  * import { Card, CardContent } from '@mui/material';
  * import * as React from 'react';

--- a/packages/ra-ui-materialui/src/list/filter/FilterLiveForm.stories.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/FilterLiveForm.stories.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import CategoryIcon from '@mui/icons-material/LocalOffer';
-import MailIcon from '@mui/icons-material/MailOutlined';
+import MailIcon from '@mui/icons-material/MailOutlineOutlined';
 import Person2Icon from '@mui/icons-material/Person2';
 import TitleIcon from '@mui/icons-material/Title';
 import { Box, Card, CardContent, Stack, Typography } from '@mui/material';

--- a/packages/ra-ui-materialui/src/list/filter/RemoveSavedQueryIconButton.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/RemoveSavedQueryIconButton.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { useState } from 'react';
 import { IconButton, IconButtonProps } from '@mui/material';
-import RemoveIcon from '@mui/icons-material/RemoveCircleOutlined';
+import RemoveIcon from '@mui/icons-material/RemoveCircleOutlineOutlined';
 import { useTranslate } from 'ra-core';
 
 import { RemoveSavedQueryDialog } from './RemoveSavedQueryDialog';

--- a/packages/ra-ui-materialui/src/list/filter/SavedQueriesList.tsx
+++ b/packages/ra-ui-materialui/src/list/filter/SavedQueriesList.tsx
@@ -7,7 +7,7 @@ import {
     useThemeProps,
 } from '@mui/material';
 import BookmarkIcon from '@mui/icons-material/BookmarkBorder';
-import HelpIcon from '@mui/icons-material/HelpOutlined';
+import HelpIcon from '@mui/icons-material/HelpOutlineOutlined';
 import {
     useListContext,
     useTranslate,

--- a/packages/ra-ui-materialui/src/preferences/Inspector.tsx
+++ b/packages/ra-ui-materialui/src/preferences/Inspector.tsx
@@ -9,7 +9,7 @@ import {
 } from 'ra-core';
 import { Paper, Typography, IconButton } from '@mui/material';
 import CloseIcon from '@mui/icons-material/CancelOutlined';
-import DeleteIcon from '@mui/icons-material/DeleteOutlined';
+import DeleteIcon from '@mui/icons-material/DeleteOutlineOutlined';
 import { useTheme, styled, ComponentsOverrides } from '@mui/material/styles';
 
 import { InspectorRoot } from './InspectorRoot';


### PR DESCRIPTION
closes #11308

## Problem

[MUI's v9 migration guide about icon paths](https://mui.com/material-ui/migration/upgrade-to-v9/#material-icons) is wrong. 

They say we should replace `AddCircleOutline` by `AddCircleOutlined`, but this is a different icon, the right component should be `AddCircleOutlineOutlined`.

We followed the guide and this caused a regression (certain outlined icons were replaced by plain ones). 

## Solution

Fix those paths:
- ErrorOutlined -> ErrorOutlineOutlined
- HelpOutlined -> HelpOutlineOutlined
- AddCircleOutlined -> AddCircleOutlineOutlined
- RemoveCircleOutlined -> RemoveCircleOutlineOutlined
- DeleteOutlined -> DeleteOutlineOutlined
- MailOutlined -> MailOutlineOutlined

All the `OutlineOutlined` icons were already present in MUI 5.16.12 (our minimal version), so the change is safe. 

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests** (if not possible, describe why)~~
- ~~[ ] The PR includes one or several **stories** (if not possible, describe why)~~
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
