### PR TITLE
[Doc] Document `<AutocompleteInput getOptionDisabled>` prop

### DIFF
--- a/docs/AutocompleteArrayInput.md
+++ b/docs/AutocompleteArrayInput.md
@@ -66,6 +66,7 @@ The form value for the source must be an array of the selected values, e.g.
 | `debounce`                 | Optional | `number`                                        | `250`                    | The delay to wait before calling the setFilter function injected when used in a ReferenceArray Input.                                                         |
 | `emptyValue`               | Optional | `any`                                           | `''`                     | The value to use for the empty element                                                                                                                  |
 | `filterToQuery`            | Optional | `string` => `Object`                            | `q => ({ q })`           | How to transform the searchText into a parameter for the data provider                                                                                  |
+| `getOptionDisabled`        | Optional | `Function`                                      | `-`                      | A function returning a `boolean` indicating whether a choice can be selected. `(choice) => boolean`                                                     |
 | `inputText`                | Optional | `Function`                                      | `-`                      | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                 |
 | `matchSuggestion`          | Optional | `Function`                                      | `-`                      | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean` |
 | `offline`                  | Optional | `ReactNode`                                     | -                        | What to render when there is no network connectivity when fetching the choices                                                                                                                                      |
@@ -325,6 +326,25 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
     <AutocompleteArrayInput filterToQuery={filterToQuery} />
 </ReferenceArrayInput>
 ```
+
+## `getOptionDisabled`
+
+By default, users can select any of the choices. Use the `getOptionDisabled` prop to prevent the selection of some of them, e.g. because they don't meet a business requirement. It takes a choice and returns a boolean.
+
+```jsx
+<ReferenceArrayInput source="recipient_ids" reference="staff">
+    <AutocompleteArrayInput
+        helperText="Only staff members with an email address can be notified"
+        getOptionDisabled={choice => !choice.email}
+    />
+</ReferenceArrayInput>
+```
+
+Disabled choices still appear in the suggestion list, but grayed out and not selectable. This is often more helpful than hiding them, as it lets users know that the choice exists. Use [the `helperText` prop](./Inputs.md#helpertext) to explain why these choices can't be selected.
+
+**Tip**: To remove these choices from the suggestion list instead of disabling them, filter them out of [the `choices` prop](#choices), or, inside a `<ReferenceArrayInput>`, use [its `filter` prop](./ReferenceArrayInput.md#filter).
+
+**Tip**: `getOptionDisabled` doesn't replace the internal logic disabling [the `createLabel` hint](#createlabel): a choice is disabled when either your function or react-admin's own rule returns `true`.
 
 ## `offline`
 

--- a/docs/AutocompleteInput.md
+++ b/docs/AutocompleteInput.md
@@ -67,6 +67,7 @@ The form value for the source must be the selected value, e.g.
 | `emptyText`                | Optional | `string`                                        | `''`                                       | The text to use for the empty element                                                                                                                                                                               |
 | `emptyValue`               | Optional | `any`                                           | `''`                                       | The value to use for the empty element                                                                                                                                                                              |
 | `filterToQuery`            | Optional | `string` => `Object`                            | `q => ({ q })`                             | How to transform the searchText into a parameter for the data provider                                                                                                                                              |
+| `getOptionDisabled`        | Optional | `Function`                                      | `-`                                        | A function returning a `boolean` indicating whether a choice can be selected. `(choice) => boolean`                                                                                                                 |
 | `isPending`                | Optional | `boolean`                                       | `false`                                    | If `true`, the component will display a loading indicator.                                                                                                                                                          |
 | `inputText`                | Optional | `Function`                                      | `-`                                        | Required if `optionText` is a custom Component, this function must return the text displayed for the current selection.                                                                                             |
 | `matchSuggestion`          | Optional | `Function`                                      | `-`                                        | Required if `optionText` is a React element. Function returning a boolean indicating whether a choice matches the filter. `(filter, choice) => boolean`                                                             |
@@ -353,6 +354,25 @@ const filterToQuery = searchText => ({ name_ilike: `%${searchText}%` });
     <AutocompleteInput filterToQuery={filterToQuery} />
 </ReferenceInput>
 ```
+
+## `getOptionDisabled`
+
+By default, users can select any of the choices. Use the `getOptionDisabled` prop to prevent the selection of some of them, e.g. because they don't meet a business requirement. It takes a choice and returns a boolean.
+
+```jsx
+<ReferenceInput source="sender_id" reference="staff">
+    <AutocompleteInput
+        helperText="Only staff members with an email address can send messages"
+        getOptionDisabled={choice => !choice.email}
+    />
+</ReferenceInput>
+```
+
+Disabled choices still appear in the suggestion list, but grayed out and not selectable. This is often more helpful than hiding them, as it lets users know that the choice exists. Use [the `helperText` prop](./Inputs.md#helpertext) to explain why these choices can't be selected.
+
+**Tip**: To remove these choices from the suggestion list instead of disabling them, filter them out of [the `choices` prop](#choices), or, inside a `<ReferenceInput>`, use [its `filter` prop](./ReferenceInput.md#filter).
+
+**Tip**: `getOptionDisabled` doesn't replace the internal logic disabling [the `createLabel` hint](#createlabel): a choice is disabled when either your function or react-admin's own rule returns `true`.
 
 ## `isPending`
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -32,7 +32,6 @@ import {
     CreateItemLabelRendered,
     FilterSelectedOptionsFalse,
     GetOptionDisabled,
-    GetOptionDisabledWithCreateLabel,
 } from './AutocompleteInput.stories';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
@@ -1723,27 +1722,6 @@ describe('<AutocompleteInput />', () => {
             fireEvent.keyDown(input, { key: 'ArrowDown' });
             fireEvent.keyDown(input, { key: 'Enter' });
             expect(input.value).toEqual('William Shakespeare');
-        });
-
-        it('should not enable the create hint', async () => {
-            render(<GetOptionDisabledWithCreateLabel />);
-            const input = (await screen.findByLabelText(
-                'Author'
-            )) as HTMLInputElement;
-            input.focus();
-            fireEvent.change(input, { target: { value: '' } });
-            expect(
-                (
-                    await screen.findByRole('option', {
-                        name: 'Start typing to create a new item',
-                    })
-                ).getAttribute('aria-disabled')
-            ).toEqual('true');
-            expect(
-                screen
-                    .getByRole('option', { name: 'Victor Hugo' })
-                    .getAttribute('aria-disabled')
-            ).toEqual('true');
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -31,6 +31,8 @@ import {
     CreateItemLabel,
     CreateItemLabelRendered,
     FilterSelectedOptionsFalse,
+    GetOptionDisabled,
+    GetOptionDisabledWithCreateLabel,
 } from './AutocompleteInput.stories';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
 import { AutocompleteArrayInput } from './AutocompleteArrayInput';
@@ -1693,6 +1695,56 @@ describe('<AutocompleteInput />', () => {
         expect(onBlur).toHaveBeenCalledWith(
             expect.objectContaining({ type: 'blur' })
         );
+    });
+
+    describe('getOptionDisabled', () => {
+        it('should disable the choices for which it returns true', async () => {
+            render(<GetOptionDisabled />);
+            (await screen.findByLabelText('Author')).focus();
+            expect(
+                (
+                    await screen.findByRole('option', { name: 'Victor Hugo' })
+                ).getAttribute('aria-disabled')
+            ).toEqual('true');
+            expect(
+                screen
+                    .getByRole('option', { name: 'William Shakespeare' })
+                    .getAttribute('aria-disabled')
+            ).toEqual('false');
+        });
+
+        it('should skip the disabled choices when navigating with the keyboard', async () => {
+            render(<GetOptionDisabled />);
+            const input = (await screen.findByLabelText(
+                'Author'
+            )) as HTMLInputElement;
+            input.focus();
+            await screen.findByRole('option', { name: 'Victor Hugo' });
+            fireEvent.keyDown(input, { key: 'ArrowDown' });
+            fireEvent.keyDown(input, { key: 'Enter' });
+            expect(input.value).toEqual('William Shakespeare');
+        });
+
+        it('should not enable the create hint', async () => {
+            render(<GetOptionDisabledWithCreateLabel />);
+            const input = (await screen.findByLabelText(
+                'Author'
+            )) as HTMLInputElement;
+            input.focus();
+            fireEvent.change(input, { target: { value: '' } });
+            expect(
+                (
+                    await screen.findByRole('option', {
+                        name: 'Start typing to create a new item',
+                    })
+                ).getAttribute('aria-disabled')
+            ).toEqual('true');
+            expect(
+                screen
+                    .getByRole('option', { name: 'Victor Hugo' })
+                    .getAttribute('aria-disabled')
+            ).toEqual('true');
+        });
     });
 
     describe('Inside <ReferenceInput>', () => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -176,6 +176,25 @@ export const Required = () => (
     </Wrapper>
 );
 
+const choicesWithEmail = [
+    { id: 1, name: 'Leo Tolstoy', email: 'leo.tolstoy@example.com' },
+    { id: 2, name: 'Victor Hugo' },
+    { id: 3, name: 'William Shakespeare', email: 'w.shakespeare@example.com' },
+    { id: 4, name: 'Charles Baudelaire', email: 'c.baudelaire@example.com' },
+    { id: 5, name: 'Marcel Proust' },
+];
+
+export const GetOptionDisabled = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={choicesWithEmail}
+            helperText="Only authors with an email address can be notified"
+            getOptionDisabled={choice => !choice.email}
+        />
+    </Wrapper>
+);
+
 export const IsPending = () => (
     <Wrapper>
         <AutocompleteInput source="author" isPending />

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -176,6 +176,25 @@ export const Required = () => (
     </Wrapper>
 );
 
+const choicesWithEmail = [
+    { id: 1, name: 'Leo Tolstoy', email: 'leo.tolstoy@example.com' },
+    { id: 2, name: 'Victor Hugo' },
+    { id: 3, name: 'William Shakespeare', email: 'w.shakespeare@example.com' },
+    { id: 4, name: 'Charles Baudelaire', email: 'c.baudelaire@example.com' },
+    { id: 5, name: 'Marcel Proust' },
+];
+
+export const GetOptionDisabled = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={choicesWithEmail}
+            helperText="Only authors with an email address can be notified"
+            getOptionDisabled={choice => !choice.email}
+        />
+    </Wrapper>
+);
+
 export const IsPending = () => (
     <Wrapper>
         <AutocompleteInput source="author" isPending />
@@ -569,6 +588,19 @@ CreateLabel.argTypes = {
         control: { type: 'inline-radio' },
     },
 };
+
+export const GetOptionDisabledWithCreateLabel = () => (
+    <Wrapper>
+        <AutocompleteInput
+            source="author"
+            choices={choicesWithEmail}
+            helperText="Only authors with an email address can be notified"
+            getOptionDisabled={choice => !choice.email}
+            onCreate={filter => ({ id: 6, name: filter })}
+            createLabel="Start typing to create a new item"
+        />
+    </Wrapper>
+);
 
 const CreateItemLabelInput = () => {
     const [choices, setChoices] = useState(choicesForCreationSupport);

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -176,25 +176,6 @@ export const Required = () => (
     </Wrapper>
 );
 
-const choicesWithEmail = [
-    { id: 1, name: 'Leo Tolstoy', email: 'leo.tolstoy@example.com' },
-    { id: 2, name: 'Victor Hugo' },
-    { id: 3, name: 'William Shakespeare', email: 'w.shakespeare@example.com' },
-    { id: 4, name: 'Charles Baudelaire', email: 'c.baudelaire@example.com' },
-    { id: 5, name: 'Marcel Proust' },
-];
-
-export const GetOptionDisabled = () => (
-    <Wrapper>
-        <AutocompleteInput
-            source="author"
-            choices={choicesWithEmail}
-            helperText="Only authors with an email address can be notified"
-            getOptionDisabled={choice => !choice.email}
-        />
-    </Wrapper>
-);
-
 export const IsPending = () => (
     <Wrapper>
         <AutocompleteInput source="author" isPending />
@@ -588,19 +569,6 @@ CreateLabel.argTypes = {
         control: { type: 'inline-radio' },
     },
 };
-
-export const GetOptionDisabledWithCreateLabel = () => (
-    <Wrapper>
-        <AutocompleteInput
-            source="author"
-            choices={choicesWithEmail}
-            helperText="Only authors with an email address can be notified"
-            getOptionDisabled={choice => !choice.email}
-            onCreate={filter => ({ id: 6, name: filter })}
-            createLabel="Start typing to create a new item"
-        />
-    </Wrapper>
-);
 
 const CreateItemLabelInput = () => {
     const [choices, setChoices] = useState(choicesForCreationSupport);


### PR DESCRIPTION
Closes #11299

## Problem

`<AutocompleteInput>` and `<AutocompleteArrayInput>` accept a `getOptionDisabled` prop to prevent the selection of some choices, but it is documented nowhere — so users can't tell whether it's a supported API. It also has no test coverage.

## Solution

Document it on both pages (props table + usage section), including the non-obvious part: it is combined with react-admin's internal `createLabel` hint logic rather than replacing it. Add a story and tests covering both cases.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-autocompleteinput--get-option-disabled

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
