### PR TITLE
feat: Allow to disable the responsive shrink of Buttons

### DIFF
--- a/docs/Buttons.md
+++ b/docs/Buttons.md
@@ -564,13 +564,14 @@ Base component for most react-admin buttons. Responsive (displays only the icon 
 
 | Prop         | Required | Type                           | Default | Description                              |
 | ------------ | -------- | ------------------------------ | ------- | ---------------------------------------- |
-| `alignIcon`  | Optional | `'left' | 'right`              | `'left'` | Icon position relative to the label     |
+| `alignIcon`  | Optional | `'left' \| 'right`              | `'left'` | Icon position relative to the label     |
+| `breakpoint` | Optional | `Breakpoint \| false`           | `'sm'`   | Breakpoint below which the button shrinks to an icon |
 | `children`   | Optional | `ReactNode`                    | -        | icon to use                             |
 | `className`  | Optional | `string`                       | -        | Class name to customize the look and feel of the button element itself          |
-| `color`      | Optional | `'default' | 'inherit'| 'primary' | 'secondary'` | `'primary'` | Label and icon color |
+| `color`      | Optional | `'default' \| 'inherit' \| 'primary' \| 'secondary'` | `'primary'` | Label and icon color |
 | `disabled`   | Optional | `boolean`                      | `false`   | If `true`, the button will be disabled |
 | `label`      | Optional | `ReactNode`                    | `false`   | The button label |
-| `size`       | Optional | `'large' | 'medium' | 'small'` | `'small'` | Button size                            |
+| `size`       | Optional | `'large' \| 'medium' \| 'small'` | `'small'` | Button size                            |
 
 Other props are passed down to [the underlying Material UI `<Button>`](https://mui.com/material-ui/api/button/).
 
@@ -580,6 +581,42 @@ The icon position relative to the label. Defaults to `left`.
 
 ```tsx
 <Button label="Ban user" onClick={handleClick} alignIcon="right" />
+```
+
+### `breakpoint`
+
+By default, `<Button>` shrinks to an icon button with a tooltip on screens smaller than the `sm` breakpoint. Use the `breakpoint` prop to change the breakpoint at which this happens, or set it to `false` to always render the full button with its label:
+
+```tsx
+// always render the label, even on mobile
+<Button label="Ban user" onClick={handleClick} breakpoint={false}>
+    <BanIcon />
+</Button>
+
+// shrink to an icon on screens smaller than the `lg` breakpoint
+<Button label="Ban user" onClick={handleClick} breakpoint="lg">
+    <BanIcon />
+</Button>
+```
+
+**Tip**: As all react-admin buttons (`<EditButton>`, `<SaveButton>`, `<DeleteButton>`, etc.) are based on `<Button>` (with the special case of [`<CreateButton>`](#createbutton)), you can disable the mobile behavior for the entire application by setting the default prop in the theme:
+
+```tsx
+const theme = {
+    ...defaultTheme,
+    components: {
+        RaButton: {
+            defaultProps: {
+                breakpoint: false,
+            },
+        },
+        RaCreateButton: {
+            defaultProps: {
+                breakpoint: false,
+            },
+        },
+    },
+};
 ```
 
 ### `children`

--- a/packages/ra-ui-materialui/src/button/Button.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.spec.tsx
@@ -4,6 +4,7 @@ import expect from 'expect';
 import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import {
+    Breakpoint,
     ReactNodeLabel,
     SimpleStringLabel,
     TranslationKeyLabel,
@@ -34,5 +35,25 @@ describe('<DeleteButton />', () => {
         render(<ReactNodeLabel i18nProvider={i18nProvider} />);
         await screen.findByText('A ReactNode');
         expect(translate).not.toHaveBeenCalled();
+    });
+    describe('breakpoint', () => {
+        it('should shrink to an icon button below the sm breakpoint by default', async () => {
+            render(<Breakpoint width="xs" />);
+            await screen.findByLabelText(/Shrinks below sm/);
+            expect(screen.queryByText(/Shrinks below sm/)).toBeNull();
+        });
+        it('should render the label above the sm breakpoint by default', async () => {
+            render(<Breakpoint width="md" />);
+            await screen.findByText(/Shrinks below sm/);
+        });
+        it('should shrink below the breakpoint passed as prop', async () => {
+            render(<Breakpoint width="md" />);
+            await screen.findByLabelText('Shrinks below lg');
+            expect(screen.queryByText('Shrinks below lg')).toBeNull();
+        });
+        it('should never shrink when breakpoint is false', async () => {
+            render(<Breakpoint width="xs" />);
+            await screen.findByText('Never shrinks');
+        });
     });
 });

--- a/packages/ra-ui-materialui/src/button/Button.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.stories.tsx
@@ -8,6 +8,10 @@ import englishMessages from 'ra-language-english';
 import { I18nContextProvider, I18nProvider } from 'ra-core';
 import { Button } from './Button';
 import { defaultTheme } from '../theme/defaultTheme';
+import {
+    DeviceTestWrapper,
+    type DeviceTestWrapperProps,
+} from '../layout/DeviceTestWrapper';
 
 export default { title: 'ra-ui-materialui/button/Button' };
 
@@ -83,6 +87,33 @@ export const WithIcon = () => (
         </UIWrapper>
     </ThemeProvider>
 );
+
+export const Breakpoint = ({
+    width,
+}: {
+    width?: DeviceTestWrapperProps['width'];
+}) => {
+    const MaybeDeviceTestWrapper = width ? DeviceTestWrapper : React.Fragment;
+    const wrapperProps = (width ? { width } : {}) as DeviceTestWrapperProps;
+
+    return (
+        <ThemeProvider theme={createTheme(defaultTheme)}>
+            <MaybeDeviceTestWrapper {...wrapperProps}>
+                <UIWrapper>
+                    <Button label="Shrinks below lg" breakpoint="lg">
+                        <AddIcon />
+                    </Button>
+                    <Button label="Shrinks below sm (default)">
+                        <AddIcon />
+                    </Button>
+                    <Button label="Never shrinks" breakpoint={false}>
+                        <AddIcon />
+                    </Button>
+                </UIWrapper>
+            </MaybeDeviceTestWrapper>
+        </ThemeProvider>
+    );
+};
 
 export const WithThemeProps = () => (
     <ThemeProvider

--- a/packages/ra-ui-materialui/src/button/Button.tsx
+++ b/packages/ra-ui-materialui/src/button/Button.tsx
@@ -5,6 +5,7 @@ import {
     Tooltip,
     IconButton,
     useMediaQuery,
+    Breakpoint,
     Theme,
 } from '@mui/material';
 import {
@@ -42,6 +43,7 @@ export const Button = React.forwardRef(function Button<
     const props = useThemeProps({ props: inProps, name: PREFIX });
     const {
         alignIcon = 'left',
+        breakpoint = 'sm',
         children,
         className,
         disabled,
@@ -61,11 +63,12 @@ export const Button = React.forwardRef(function Button<
     }
     const linkParams = getLinkParams(locationDescriptor);
 
-    const isXSmall = useMediaQuery((theme: Theme) =>
-        theme.breakpoints.down('sm')
+    const isBelowBreakpoint = useMediaQuery((theme: Theme) =>
+        theme.breakpoints.down(breakpoint || 'xs')
     );
+    const shrink = breakpoint !== false && isBelowBreakpoint;
 
-    return isXSmall ? (
+    return shrink ? (
         label && !disabled ? (
             <Tooltip title={translatedLabel}>
                 <IconButton
@@ -123,6 +126,7 @@ export const Button = React.forwardRef(function Button<
 
 interface Props<RootComponent extends React.ElementType> {
     alignIcon?: 'left' | 'right';
+    breakpoint?: Breakpoint | false;
     children?: React.ReactNode;
     className?: string;
     component?: RootComponent;

--- a/packages/ra-ui-materialui/src/button/CreateButton.spec.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.spec.tsx
@@ -5,6 +5,7 @@ import expect from 'expect';
 import {
     Basic,
     AccessControl,
+    Breakpoint,
     Label,
     WithTooltip,
 } from './CreateButton.stories';
@@ -59,5 +60,10 @@ describe('<CreateButton />', () => {
         const button = await screen.findByLabelText('Create book');
         await user.hover(button);
         await screen.findByText('Create book');
+    });
+
+    it('should not turn into a Floating Action Button on mobile when breakpoint is false', async () => {
+        render(<Breakpoint width="sm" />);
+        await screen.findByText('Create');
     });
 });

--- a/packages/ra-ui-materialui/src/button/CreateButton.stories.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.stories.tsx
@@ -3,6 +3,10 @@ import polyglotI18nProvider from 'ra-i18n-polyglot';
 import englishMessages from 'ra-language-english';
 import frenchMessages from 'ra-language-french';
 import { Tooltip } from '@mui/material';
+import {
+    DeviceTestWrapper,
+    type DeviceTestWrapperProps,
+} from '../layout/DeviceTestWrapper';
 
 import {
     AuthProvider,
@@ -74,6 +78,27 @@ export const Basic = ({ buttonProps }: { buttonProps?: any }) => (
         </AdminContext>
     </TestMemoryRouter>
 );
+
+export const Breakpoint = ({
+    width,
+}: {
+    width?: DeviceTestWrapperProps['width'];
+}) => {
+    const MaybeDeviceTestWrapper = width ? DeviceTestWrapper : React.Fragment;
+    const wrapperProps = (width ? { width } : {}) as DeviceTestWrapperProps;
+
+    return (
+        <TestMemoryRouter>
+            <AdminContext i18nProvider={defaultI18nProvider()}>
+                <MaybeDeviceTestWrapper {...wrapperProps}>
+                    <ResourceContextProvider value="books">
+                        <CreateButton breakpoint={false} />
+                    </ResourceContextProvider>
+                </MaybeDeviceTestWrapper>
+            </AdminContext>
+        </TestMemoryRouter>
+    );
+};
 
 export const WithTooltip = () => (
     <TestMemoryRouter>

--- a/packages/ra-ui-materialui/src/button/CreateButton.tsx
+++ b/packages/ra-ui-materialui/src/button/CreateButton.tsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import ContentAdd from '@mui/icons-material/Add';
-import { Fab, useMediaQuery, type Theme } from '@mui/material';
+import { Fab, useMediaQuery, type Breakpoint, type Theme } from '@mui/material';
 import {
     type ComponentsOverrides,
     styled,
@@ -43,6 +43,7 @@ const CreateButton = React.forwardRef(function CreateButton(
         name: PREFIX,
     });
     const {
+        breakpoint = 'md',
         className,
         icon = defaultIcon,
         label: labelProp,
@@ -76,9 +77,10 @@ const CreateButton = React.forwardRef(function CreateButton(
         },
         userText: labelProp,
     });
-    const isSmall = useMediaQuery((theme: Theme) =>
-        theme.breakpoints.down('md')
+    const isBelowBreakpoint = useMediaQuery((theme: Theme) =>
+        theme.breakpoints.down(breakpoint || 'xs')
     );
+    const shrink = breakpoint !== false && isBelowBreakpoint;
     const state = merge(
         {},
         scrollStates.get(String(scrollToTop)),
@@ -90,7 +92,7 @@ const CreateButton = React.forwardRef(function CreateButton(
     if (!canAccess || isPending) {
         return null;
     }
-    return isSmall ? (
+    return shrink ? (
         <StyledFab
             component={LinkBase}
             ref={ref}
@@ -113,6 +115,7 @@ const CreateButton = React.forwardRef(function CreateButton(
             to={createPath({ resource, type: 'create' })}
             state={state}
             className={clsx(CreateButtonClasses.root, className)}
+            breakpoint={breakpoint}
             // avoid double translation
             label={<>{label}</>}
             // If users provide a ReactNode as label, its their responsibility to also provide an aria-label should they need it
@@ -135,6 +138,7 @@ const scrollStates = new Map([
 const defaultIcon = <ContentAdd />;
 
 interface Props {
+    breakpoint?: Breakpoint | false;
     resource?: string;
     icon?: React.ReactNode;
     scrollToTop?: boolean;

--- a/packages/ra-ui-materialui/src/layout/DeviceTestWrapper.tsx
+++ b/packages/ra-ui-materialui/src/layout/DeviceTestWrapper.tsx
@@ -5,7 +5,7 @@ import { createTheme, ThemeProvider } from '@mui/material/styles';
 function createMatchMedia(width) {
     return query => ({
         matches: mediaQuery.match(query, {
-            width,
+            width: `${width}px`,
         }),
         addListener: () => {},
         removeListener: () => {},


### PR DESCRIPTION
Closes #8720

## Problem

Action buttons always collapse to an icon button below the `sm` breakpoint (and <CreateButton> to a FAB below `md`), with no way to opt out short of reimplementing the buttons.

## Solution

Add a `breakpoint` prop to control the threshold, or disable the behavior entirely with `breakpoint={false}`. Defaults preserve the current behavior, and the prop is themable via `RaButton.defaultProps` so it can be turned off application-wide.

## How To Test

See "Button > Breakpoint" and "CreateButton > Breakpoint" stories.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
