### PR TITLE
feat: Add `placeholder` prop to `<SelectArrayInput>`

### DIFF
--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -72,6 +72,7 @@ The form value for the source must be an array of the selected values, e.g.
 | `options`         | Optional | `Object`                    | -                   | Props to pass to the underlying `<SelectInput>` element                                                                                |
 | `optionText`      | Optional | `string` &#124; `Function`  | `name`              | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
 | `optionValue`     | Optional | `string`                    | `id`                | Field name of record containing the value to use as input value                                                                        |
+| `placeholder`     | Optional | `string` &#124; `ReactNode` | -                   | The text to display when no choice is selected                                                                                         |
 | `translateChoice` | Optional | `boolean`                   | `true`              | Whether the choices should be translated                                                                                               |
 
 `<SelectArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
@@ -408,14 +409,46 @@ const choices = [
 
 **Note:** `optionValue` is only supported when the choices are provided directly via the `choices` prop. If you use `<SelectArrayInput>` inside a `<ReferenceArrayInput>`, the `optionValue` is always set to `id`, as the choices are records fetched from the related resource, and [records should always have an `id` field](./FAQ.md#can-i-have-custom-identifiersprimary-keys-for-my-resources).
 
+## `placeholder`
+
+When no choice is selected, `<SelectArrayInput>` renders an empty input. Use the `placeholder` prop to render a text instead:
+
+```jsx
+const channelChoices = [
+    { id: 'email', name: 'Email' },
+    { id: 'push', name: 'Push Notification' },
+    { id: 'sms', name: 'SMS' },
+];
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="All Channels" />
+```
+
+This is especially useful in filters, to tell users what happens when they don't select any choice.
+
+As soon as the user selects a choice, the placeholder gives way to the chips of the selected choices.
+
+The `placeholder` prop accepts either a string or a React element:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
+```
+
+String placeholders are translated, so you can use a translation key:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="myapp.channels.all" />
+```
+
+**Note**: Setting a `placeholder` keeps the input label above the input (i.e. in its shrunk state) even when no choice is selected, so that the label and the placeholder don't overlap.
+
 ## `sx`: CSS API
 
 The `<SelectArrayInput>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (see [the `sx` documentation](./SX.md) for syntax and examples). This property accepts the following subclasses:
 
-| Rule name                     | Description                                                                        |
-|-------------------------------|------------------------------------------------------------------------------------|
-| `& .RaSelectArrayInput-chip`  | Applied to each Material UI's `Chip` component used as selected item               |
-| `& .RaSelectArrayInput-chips` | Applied to the container of Material UI's `Chip` components used as selected items |
+| Rule name                           | Description                                                                        |
+|-------------------------------------|------------------------------------------------------------------------------------|
+| `& .RaSelectArrayInput-chip`        | Applied to each Material UI's `Chip` component used as selected item               |
+| `& .RaSelectArrayInput-chips`       | Applied to the container of Material UI's `Chip` components used as selected items |
+| `& .RaSelectArrayInput-placeholder` | Applied to the `placeholder` element, rendered when no choice is selected          |
 
 To override the style of all instances of `<SelectArrayInput>` using the [application-wide style overrides](./AppTheme.md#theming-individual-components), use the `RaSelectArrayInput` key.
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -19,6 +19,9 @@ import {
     InsideReferenceArrayInputDefaultValue,
     CreateLabel,
     CreateLabelRendered,
+    Placeholder,
+    PlaceholderElement,
+    PlaceholderTranslated,
 } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
@@ -785,6 +788,34 @@ describe('<SelectArrayInput />', () => {
         await screen.findByText('Foo');
         fireEvent.click(screen.getByLabelText('Add'));
         expect(await screen.findAllByText('Foo')).toHaveLength(2);
+    });
+
+    describe('placeholder', () => {
+        it('should render the placeholder when no choice is selected', async () => {
+            render(<Placeholder />);
+            await screen.findByText('All Channels');
+        });
+
+        it('should render the selected choices instead of the placeholder', async () => {
+            render(<Placeholder />);
+            await screen.findByText('All Channels');
+            fireEvent.mouseDown(screen.getByLabelText('Channels'));
+            fireEvent.click(screen.getByText('Email'));
+            await waitFor(() => {
+                expect(screen.queryByText('All Channels')).toBeNull();
+            });
+            expect(screen.getByDisplayValue('email')).not.toBeNull();
+        });
+
+        it('should accept a React element as placeholder', async () => {
+            render(<PlaceholderElement />);
+            await screen.findByText('All Channels');
+        });
+
+        it('should translate the placeholder', async () => {
+            render(<PlaceholderTranslated />);
+            await screen.findByText('All Channels');
+        });
     });
 
     describe('inside ReferenceArrayInput', () => {

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -291,6 +291,62 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
+export const Placeholder = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="channels"
+            choices={[
+                { id: 'email', name: 'Email' },
+                { id: 'push', name: 'Push Notification' },
+                { id: 'sms', name: 'SMS' },
+            ]}
+            placeholder="All Channels"
+            sx={{ width: 300 }}
+        />
+        <FormInspector name="channels" />
+    </Wrapper>
+);
+
+export const PlaceholderElement = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="channels"
+            choices={[
+                { id: 'email', name: 'Email' },
+                { id: 'push', name: 'Push Notification' },
+                { id: 'sms', name: 'SMS' },
+            ]}
+            placeholder={<i>All Channels</i>}
+            sx={{ width: 300 }}
+        />
+    </Wrapper>
+);
+
+export const PlaceholderTranslated = () => (
+    <AdminContext
+        i18nProvider={polyglotI18nProvider(() => ({
+            ...englishMessages,
+            myapp: { channels: { placeholder: 'All Channels' } },
+        }))}
+        defaultTheme="light"
+    >
+        <Create resource="posts" sx={{ width: 600 }}>
+            <SimpleForm>
+                <SelectArrayInput
+                    source="channels"
+                    choices={[
+                        { id: 'email', name: 'Email' },
+                        { id: 'push', name: 'Push Notification' },
+                        { id: 'sms', name: 'SMS' },
+                    ]}
+                    placeholder="myapp.channels.placeholder"
+                    sx={{ width: 300 }}
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
 export const InsideArrayInput = () => (
     <Wrapper>
         <ArrayInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -4,7 +4,7 @@ import {
     styled,
     useThemeProps,
 } from '@mui/material/styles';
-import { useCallback, useRef, type ChangeEvent } from 'react';
+import { useCallback, useRef, type ChangeEvent, type ReactNode } from 'react';
 import clsx from 'clsx';
 import {
     Select,
@@ -28,6 +28,7 @@ import {
     useGetRecordRepresentation,
     type SupportCreateSuggestionOptions,
     useSupportCreateSuggestion,
+    useTranslate,
 } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
 
@@ -89,6 +90,14 @@ import { Labeled } from '../Labeled';
  *    { id: 'lifestyle', name: 'myroot.tags.lifestyle' },
  *    { id: 'photography', name: 'myroot.tags.photography' },
  * ];
+ *
+ * Use the `placeholder` prop to render a custom text when no choice is selected:
+ * @example
+ * const channelChoices = [
+ *    { id: 'email', name: 'Email' },
+ *    { id: 'push', name: 'Push Notification' },
+ * ];
+ * <SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
  */
 export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     const props = useThemeProps({
@@ -117,6 +126,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
         optionText,
         optionValue = 'id',
         parse,
+        placeholder,
         resource: resourceProp,
         size = 'small',
         source: sourceProp,
@@ -129,6 +139,8 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     } = props;
 
     const inputLabel = useRef(null);
+    const translate = useTranslate();
+    const hasPlaceholder = placeholder != null && placeholder !== '';
 
     const {
         allChoices,
@@ -308,6 +320,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     ref={inputLabel}
                     id={`${id}-outlined-label`}
                     htmlFor={id}
+                    shrink={hasPlaceholder ? true : undefined}
                     {...InputLabelProps}
                 >
                     <FieldTitle
@@ -330,17 +343,30 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     }
                     multiple
                     error={!!fetchError || invalid}
-                    renderValue={(selected: any[]) => (
-                        <div className={SelectArrayInputClasses.chips}>
-                            {(Array.isArray(selected) ? selected : [])
-                                .map(item =>
-                                    (allChoices || []).find(
-                                        // eslint-disable-next-line eqeqeq
-                                        choice => getChoiceValue(choice) == item
-                                    )
+                    displayEmpty={hasPlaceholder ? true : undefined}
+                    renderValue={(selected: any[]) => {
+                        const selectedChoices = (
+                            Array.isArray(selected) ? selected : []
+                        )
+                            .map(item =>
+                                (allChoices || []).find(
+                                    // eslint-disable-next-line eqeqeq
+                                    choice => getChoiceValue(choice) == item
                                 )
-                                .filter(item => !!item)
-                                .map(item => (
+                            )
+                            .filter(item => !!item);
+                        return selectedChoices.length === 0 &&
+                            hasPlaceholder ? (
+                            <span
+                                className={SelectArrayInputClasses.placeholder}
+                            >
+                                {typeof placeholder === 'string'
+                                    ? translate(placeholder, { _: placeholder })
+                                    : placeholder}
+                            </span>
+                        ) : (
+                            <div className={SelectArrayInputClasses.chips}>
+                                {selectedChoices.map(item => (
                                     <Chip
                                         key={getChoiceValue(item)}
                                         label={renderMenuItemOption(item)}
@@ -348,8 +374,9 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                                         size="small"
                                     />
                                 ))}
-                        </div>
-                    )}
+                            </div>
+                        );
+                    }}
                     disabled={disabled || readOnly}
                     readOnly={readOnly}
                     data-testid="selectArray"
@@ -379,9 +406,13 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
 export type SelectArrayInputProps = ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &
     Omit<CommonInputProps, 'source'> &
-    Omit<FormControlProps, 'defaultValue' | 'onBlur' | 'onChange'> & {
+    Omit<
+        FormControlProps,
+        'defaultValue' | 'onBlur' | 'onChange' | 'placeholder'
+    > & {
         options?: SelectProps;
         InputLabelProps?: Omit<InputLabelProps, 'htmlFor' | 'id' | 'ref'>;
+        placeholder?: ReactNode;
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
     };
@@ -429,6 +460,7 @@ const PREFIX = 'RaSelectArrayInput';
 export const SelectArrayInputClasses = {
     chips: `${PREFIX}-chips`,
     chip: `${PREFIX}-chip`,
+    placeholder: `${PREFIX}-placeholder`,
 };
 
 const StyledFormControl = styled(FormControl, {
@@ -448,13 +480,17 @@ const StyledFormControl = styled(FormControl, {
         marginTop: theme.spacing(0.5),
         marginRight: theme.spacing(0.5),
     },
+
+    [`& .${SelectArrayInputClasses.placeholder}`]: {
+        color: (theme.vars || theme).palette.text.secondary,
+    },
 }));
 
 const defaultOptions = {};
 
 declare module '@mui/material/styles' {
     interface ComponentNameToClassKey {
-        RaSelectArrayInput: 'root' | 'chips' | 'chip';
+        RaSelectArrayInput: 'root' | 'chips' | 'chip' | 'placeholder';
     }
 
     interface ComponentsPropsList {


### PR DESCRIPTION
# Problem

`<SelectArrayInput>` cannot render a custom text when no choice is selected (e.g. "All Channels" in a filter).

Closes #10454.

## Solution

Add a `placeholder` prop, rendered in place of the chips while the value is empty.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-selectarrayinput--placeholder

## Additional Checks

- [ ] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
