### PR TITLE
feat: Add `placeholder` prop to `<SelectArrayInput>`

### DIFF
--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -419,26 +419,34 @@ const channelChoices = [
     { id: 'push', name: 'Push Notification' },
     { id: 'sms', name: 'SMS' },
 ];
-<SelectArrayInput source="channels" choices={channelChoices} placeholder="All Channels" />
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="No channel" />
 ```
 
-This is especially useful in filters, to tell users what happens when they don't select any choice.
-
 As soon as the user selects a choice, the placeholder gives way to the chips of the selected choices.
+
+The prop is especially useful in filters, where selecting no choice means "don't filter on that field". The placeholder is then the place to say so:
+
+```jsx
+const postFilters = [
+    <SelectArrayInput source="channels" choices={channelChoices} placeholder="All channels" alwaysOn />,
+];
+```
 
 The `placeholder` prop accepts either a string or a React element:
 
 ```jsx
-<SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
+<SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>No channel</i>} />
 ```
 
 String placeholders are translated, so you can use a translation key:
 
 ```jsx
-<SelectArrayInput source="channels" choices={channelChoices} placeholder="myapp.channels.all" />
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="myapp.channels.none" />
 ```
 
 **Note**: Setting a `placeholder` keeps the input label above the input (i.e. in its shrunk state) even when no choice is selected, so that the label and the placeholder don't overlap.
+
+**Tip**: `placeholder` renders *inside the input*. It is not the equivalent of [`<SelectInput emptyText>`](./SelectInput.md#emptytext), which adds an empty *option* to the dropdown to let users unselect their choice - a multi-selection needs no such option, as users can unselect a choice by clicking it again.
 
 ## `sx`: CSS API
 

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -72,6 +72,7 @@ The form value for the source must be an array of the selected values, e.g.
 | `options`         | Optional | `Object`                    | -                   | Props to pass to the underlying `<SelectInput>` element                                                                                |
 | `optionText`      | Optional | `string` &#124; `Function`  | `name`              | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
 | `optionValue`     | Optional | `string`                    | `id`                | Field name of record containing the value to use as input value                                                                        |
+| `placeholder`     | Optional | `string` &#124; `ReactNode` | -                   | The text to display when no choice is selected                                                                                         |
 | `translateChoice` | Optional | `boolean`                   | `true`              | Whether the choices should be translated                                                                                               |
 
 `<SelectArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
@@ -408,14 +409,46 @@ const choices = [
 
 **Note:** `optionValue` is only supported when the choices are provided directly via the `choices` prop. If you use `<SelectArrayInput>` inside a `<ReferenceArrayInput>`, the `optionValue` is always set to `id`, as the choices are records fetched from the related resource, and [records should always have an `id` field](./FAQ.md#can-i-have-custom-identifiersprimary-keys-for-my-resources).
 
+## `placeholder`
+
+When no choice is selected, `<SelectArrayInput>` renders an empty input. Use the `placeholder` prop to render a text instead:
+
+```jsx
+const channelChoices = [
+    { id: 'email', name: 'Email' },
+    { id: 'push', name: 'Push Notification' },
+    { id: 'sms', name: 'SMS' },
+];
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="All Channels" />
+```
+
+This is especially useful in filters, to tell users what happens when they don't select any choice.
+
+As soon as the user selects a choice, the placeholder gives way to the chips of the selected choices.
+
+The `placeholder` prop accepts either a string or a React element:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
+```
+
+String placeholders are translated, so you can use a translation key:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} placeholder="myapp.channels.all" />
+```
+
+**Note**: Setting a `placeholder` keeps the input label above the input (i.e. in its shrunk state) even when no choice is selected, so that the label and the placeholder don't overlap.
+
 ## `sx`: CSS API
 
 The `<SelectArrayInput>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (see [the `sx` documentation](./SX.md) for syntax and examples). This property accepts the following subclasses:
 
-| Rule name                     | Description                                                                        |
-|-------------------------------|------------------------------------------------------------------------------------|
-| `& .RaSelectArrayInput-chip`  | Applied to each Material UI's `Chip` component used as selected item               |
-| `& .RaSelectArrayInput-chips` | Applied to the container of Material UI's `Chip` components used as selected items |
+| Rule name                           | Description                                                                        |
+|-------------------------------------|------------------------------------------------------------------------------------|
+| `& .RaSelectArrayInput-chip`        | Applied to each Material UI's `Chip` component used as selected item               |
+| `& .RaSelectArrayInput-chips`       | Applied to the container of Material UI's `Chip` components used as selected items |
+| `& .RaSelectArrayInput-placeholder` | Applied to the `placeholder` element, rendered when no choice is selected          |
 
 To override the style of all instances of `<SelectArrayInput>` using the [application-wide style overrides](./AppTheme.md#theming-individual-components), use the `RaSelectArrayInput` key.
 

--- a/docs/SelectArrayInput.md
+++ b/docs/SelectArrayInput.md
@@ -67,12 +67,12 @@ The form value for the source must be an array of the selected values, e.g.
 | `create`          | Optional | `Element`                   | -                   | A React Element to render when users want to create a new choice                                                                       |
 | `createLabel`     | Optional | `string` &#124; `ReactNode` | `ra.action. create` | The label for the menu item allowing users to create a new choice. Used when the filter is empty                                       |
 | `disableValue`    | Optional | `string`                    | 'disabled'          | The custom field name used in `choices` to disable some choices                                                                        |
+| `emptyText`       | Optional | `string` &#124; `ReactNode` | -                   | The text to display when no choice is selected                                                                                         |
 | `InputLabelProps` | Optional | `Object`                    | -                   | Props to pass to the underlying `<InputLabel>` element                                                                                 |
 | `onCreate`        | Optional | `Function`                  | -                   | A function called with the current filter value when users choose to create a new choice.                                              |
 | `options`         | Optional | `Object`                    | -                   | Props to pass to the underlying `<SelectInput>` element                                                                                |
 | `optionText`      | Optional | `string` &#124; `Function`  | `name`              | Field name of record to display in the suggestion item or function which accepts the current record as argument (`record => {string}`) |
 | `optionValue`     | Optional | `string`                    | `id`                | Field name of record containing the value to use as input value                                                                        |
-| `placeholder`     | Optional | `string` &#124; `ReactNode` | -                   | The text to display when no choice is selected                                                                                         |
 | `translateChoice` | Optional | `boolean`                   | `true`              | Whether the choices should be translated                                                                                               |
 
 `<SelectArrayInput>` also accepts the [common input props](./Inputs.md#common-input-props).
@@ -284,6 +284,45 @@ const choices = [
 <SelectArrayInput source="roles" choices={choices} disableValue="not_available" />
 ```
 
+## `emptyText`
+
+When no choice is selected, `<SelectArrayInput>` renders an empty input. Use the `emptyText` prop to render a text instead:
+
+```jsx
+const channelChoices = [
+    { id: 'email', name: 'Email' },
+    { id: 'push', name: 'Push Notification' },
+    { id: 'sms', name: 'SMS' },
+];
+<SelectArrayInput source="channels" choices={channelChoices} emptyText="No channel" />
+```
+
+As soon as the user selects a choice, the empty text gives way to the chips of the selected choices.
+
+The prop is especially useful in filters, where selecting no choice means "don't filter on that field". The empty text is then the place to say so:
+
+```jsx
+const postFilters = [
+    <SelectArrayInput source="channels" choices={channelChoices} emptyText="All channels" alwaysOn />,
+];
+```
+
+The `emptyText` prop accepts either a string or a React element:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} emptyText={<i>No channel</i>} />
+```
+
+Strings are translated, so you can use a translation key:
+
+```jsx
+<SelectArrayInput source="channels" choices={channelChoices} emptyText="myapp.channels.none" />
+```
+
+**Note**: Setting an `emptyText` keeps the input label above the input (i.e. in its shrunk state) even when no choice is selected, so that the label and the empty text don't overlap.
+
+**Tip**: Unlike [`<SelectInput emptyText>`](./SelectInput.md#emptytext), which adds an empty *option* to the dropdown to let users unselect their choice, `<SelectArrayInput emptyText>` only renders inside the input. A multi-selection needs no empty option, as users can unselect a choice by clicking it again.
+
 ## `InputLabelProps`
 
 Use the `options` attribute if you want to override Material UI's `<InputLabel>` attributes:
@@ -409,54 +448,15 @@ const choices = [
 
 **Note:** `optionValue` is only supported when the choices are provided directly via the `choices` prop. If you use `<SelectArrayInput>` inside a `<ReferenceArrayInput>`, the `optionValue` is always set to `id`, as the choices are records fetched from the related resource, and [records should always have an `id` field](./FAQ.md#can-i-have-custom-identifiersprimary-keys-for-my-resources).
 
-## `placeholder`
-
-When no choice is selected, `<SelectArrayInput>` renders an empty input. Use the `placeholder` prop to render a text instead:
-
-```jsx
-const channelChoices = [
-    { id: 'email', name: 'Email' },
-    { id: 'push', name: 'Push Notification' },
-    { id: 'sms', name: 'SMS' },
-];
-<SelectArrayInput source="channels" choices={channelChoices} placeholder="No channel" />
-```
-
-As soon as the user selects a choice, the placeholder gives way to the chips of the selected choices.
-
-The prop is especially useful in filters, where selecting no choice means "don't filter on that field". The placeholder is then the place to say so:
-
-```jsx
-const postFilters = [
-    <SelectArrayInput source="channels" choices={channelChoices} placeholder="All channels" alwaysOn />,
-];
-```
-
-The `placeholder` prop accepts either a string or a React element:
-
-```jsx
-<SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>No channel</i>} />
-```
-
-String placeholders are translated, so you can use a translation key:
-
-```jsx
-<SelectArrayInput source="channels" choices={channelChoices} placeholder="myapp.channels.none" />
-```
-
-**Note**: Setting a `placeholder` keeps the input label above the input (i.e. in its shrunk state) even when no choice is selected, so that the label and the placeholder don't overlap.
-
-**Tip**: `placeholder` renders *inside the input*. It is not the equivalent of [`<SelectInput emptyText>`](./SelectInput.md#emptytext), which adds an empty *option* to the dropdown to let users unselect their choice - a multi-selection needs no such option, as users can unselect a choice by clicking it again.
-
 ## `sx`: CSS API
 
 The `<SelectArrayInput>` component accepts the usual `className` prop. You can also override many styles of the inner components thanks to the `sx` property (see [the `sx` documentation](./SX.md) for syntax and examples). This property accepts the following subclasses:
 
-| Rule name                           | Description                                                                        |
-|-------------------------------------|------------------------------------------------------------------------------------|
-| `& .RaSelectArrayInput-chip`        | Applied to each Material UI's `Chip` component used as selected item               |
-| `& .RaSelectArrayInput-chips`       | Applied to the container of Material UI's `Chip` components used as selected items |
-| `& .RaSelectArrayInput-placeholder` | Applied to the `placeholder` element, rendered when no choice is selected          |
+| Rule name                          | Description                                                                        |
+|------------------------------------|------------------------------------------------------------------------------------|
+| `& .RaSelectArrayInput-chip`       | Applied to each Material UI's `Chip` component used as selected item               |
+| `& .RaSelectArrayInput-chips`      | Applied to the container of Material UI's `Chip` components used as selected items |
+| `& .RaSelectArrayInput-emptyText`  | Applied to the `emptyText` element, rendered when no choice is selected            |
 
 To override the style of all instances of `<SelectArrayInput>` using the [application-wide style overrides](./AppTheme.md#theming-individual-components), use the `RaSelectArrayInput` key.
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -19,10 +19,10 @@ import {
     InsideReferenceArrayInputDefaultValue,
     CreateLabel,
     CreateLabelRendered,
-    Placeholder,
-    PlaceholderElement,
-    PlaceholderInFilter,
-    PlaceholderTranslated,
+    EmptyText,
+    EmptyTextElement,
+    EmptyTextInFilter,
+    EmptyTextTranslated,
 } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
@@ -791,14 +791,14 @@ describe('<SelectArrayInput />', () => {
         expect(await screen.findAllByText('Foo')).toHaveLength(2);
     });
 
-    describe('placeholder', () => {
-        it('should render the placeholder when no choice is selected', async () => {
-            render(<Placeholder />);
+    describe('emptyText', () => {
+        it('should render the empty text when no choice is selected', async () => {
+            render(<EmptyText />);
             await screen.findByText('No channel');
         });
 
-        it('should render the selected choices instead of the placeholder', async () => {
-            render(<Placeholder />);
+        it('should render the selected choices instead of the empty text', async () => {
+            render(<EmptyText />);
             await screen.findByText('No channel');
             fireEvent.mouseDown(screen.getByLabelText('Channels'));
             fireEvent.click(screen.getByText('Email'));
@@ -808,18 +808,18 @@ describe('<SelectArrayInput />', () => {
             expect(screen.getByDisplayValue('email')).not.toBeNull();
         });
 
-        it('should accept a React element as placeholder', async () => {
-            render(<PlaceholderElement />);
+        it('should accept a React element as empty text', async () => {
+            render(<EmptyTextElement />);
             await screen.findByText('No channel');
         });
 
-        it('should translate the placeholder', async () => {
-            render(<PlaceholderTranslated />);
+        it('should translate the empty text', async () => {
+            render(<EmptyTextTranslated />);
             await screen.findByText('No channel');
         });
 
-        it('should render the placeholder in a filter', async () => {
-            render(<PlaceholderInFilter />);
+        it('should render the empty text in a filter', async () => {
+            render(<EmptyTextInFilter />);
             await screen.findByText('All channels');
         });
     });

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -19,6 +19,9 @@ import {
     InsideReferenceArrayInputDefaultValue,
     CreateLabel,
     CreateLabelRendered,
+    Placeholder,
+    PlaceholderElement,
+    PlaceholderTranslated,
 } from './SelectArrayInput.stories';
 
 describe('<SelectArrayInput />', () => {
@@ -785,6 +788,34 @@ describe('<SelectArrayInput />', () => {
         await screen.findByText('Foo');
         fireEvent.click(screen.getByLabelText('Add'));
         expect(await screen.findAllByText('Foo')).toHaveLength(2);
+    });
+
+    describe('placeholder', () => {
+        it('should render the placeholder when no choice is selected', async () => {
+            render(<Placeholder />);
+            await screen.findByText('All Channels');
+        });
+
+        it('should render the selected choices instead of the placeholder', async () => {
+            render(<Placeholder />);
+            await screen.findByText('All Channels');
+            fireEvent.mouseDown(screen.getByLabelText('Channels'));
+            fireEvent.click(screen.getByText('Email'));
+            await waitFor(() => {
+                expect(screen.queryByText('All Channels')).toBeNull();
+            });
+            expect(screen.getByDisplayValue('email')).not.toBeNull();
+        });
+
+        it('should accept a React element as placeholder', async () => {
+            render(<PlaceholderElement />);
+            await screen.findByText('All Channels');
+        });
+
+        it('should translate the placeholder', async () => {
+            render(<PlaceholderTranslated />);
+            await screen.findByText('All Channels');
+        });
     });
 
     describe('inside ReferenceArrayInput', () => {

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.spec.tsx
@@ -21,6 +21,7 @@ import {
     CreateLabelRendered,
     Placeholder,
     PlaceholderElement,
+    PlaceholderInFilter,
     PlaceholderTranslated,
 } from './SelectArrayInput.stories';
 
@@ -793,28 +794,33 @@ describe('<SelectArrayInput />', () => {
     describe('placeholder', () => {
         it('should render the placeholder when no choice is selected', async () => {
             render(<Placeholder />);
-            await screen.findByText('All Channels');
+            await screen.findByText('No channel');
         });
 
         it('should render the selected choices instead of the placeholder', async () => {
             render(<Placeholder />);
-            await screen.findByText('All Channels');
+            await screen.findByText('No channel');
             fireEvent.mouseDown(screen.getByLabelText('Channels'));
             fireEvent.click(screen.getByText('Email'));
             await waitFor(() => {
-                expect(screen.queryByText('All Channels')).toBeNull();
+                expect(screen.queryByText('No channel')).toBeNull();
             });
             expect(screen.getByDisplayValue('email')).not.toBeNull();
         });
 
         it('should accept a React element as placeholder', async () => {
             render(<PlaceholderElement />);
-            await screen.findByText('All Channels');
+            await screen.findByText('No channel');
         });
 
         it('should translate the placeholder', async () => {
             render(<PlaceholderTranslated />);
-            await screen.findByText('All Channels');
+            await screen.findByText('No channel');
+        });
+
+        it('should render the placeholder in a filter', async () => {
+            render(<PlaceholderInFilter />);
+            await screen.findByText('All channels');
         });
     });
 

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -291,6 +291,62 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
+export const Placeholder = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="channels"
+            choices={[
+                { id: 'email', name: 'Email' },
+                { id: 'push', name: 'Push Notification' },
+                { id: 'sms', name: 'SMS' },
+            ]}
+            placeholder="All Channels"
+            sx={{ width: 300 }}
+        />
+        <FormInspector name="channels" />
+    </Wrapper>
+);
+
+export const PlaceholderElement = () => (
+    <Wrapper>
+        <SelectArrayInput
+            source="channels"
+            choices={[
+                { id: 'email', name: 'Email' },
+                { id: 'push', name: 'Push Notification' },
+                { id: 'sms', name: 'SMS' },
+            ]}
+            placeholder={<i>All Channels</i>}
+            sx={{ width: 300 }}
+        />
+    </Wrapper>
+);
+
+export const PlaceholderTranslated = () => (
+    <AdminContext
+        i18nProvider={polyglotI18nProvider(() => ({
+            ...englishMessages,
+            myapp: { channels: { placeholder: 'All Channels' } },
+        }))}
+        defaultTheme="light"
+    >
+        <Create resource="posts" sx={{ width: 600 }}>
+            <SimpleForm>
+                <SelectArrayInput
+                    source="channels"
+                    choices={[
+                        { id: 'email', name: 'Email' },
+                        { id: 'push', name: 'Push Notification' },
+                        { id: 'sms', name: 'SMS' },
+                    ]}
+                    placeholder="myapp.channels.placeholder"
+                    sx={{ width: 300 }}
+                />
+            </SimpleForm>
+        </Create>
+    </AdminContext>
+);
+
 export const InsideArrayInput = () => (
     <Wrapper>
         <ArrayInput

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -8,7 +8,7 @@ import {
     DialogTitle,
     IconButton,
     Stack,
-    TextField,
+    TextField as MuiTextField,
     Typography,
 } from '@mui/material';
 import fakeRestProvider from 'ra-data-fakerest';
@@ -25,7 +25,9 @@ import {
 import { AdminContext } from '../AdminContext';
 import { AdminUI } from '../AdminUI';
 import { Create, Edit } from '../detail';
+import { TextField } from '../field';
 import { SimpleForm } from '../form';
+import { Datagrid, List } from '../list';
 import { ArrayInput, SimpleFormIterator } from './ArrayInput';
 import { FormInspector } from './common';
 import { ReferenceArrayInput } from './ReferenceArrayInput';
@@ -291,16 +293,18 @@ export const DefaultValue = () => (
     </Wrapper>
 );
 
+const channelChoices = [
+    { id: 'email', name: 'Email' },
+    { id: 'push', name: 'Push Notification' },
+    { id: 'sms', name: 'SMS' },
+];
+
 export const Placeholder = () => (
     <Wrapper>
         <SelectArrayInput
             source="channels"
-            choices={[
-                { id: 'email', name: 'Email' },
-                { id: 'push', name: 'Push Notification' },
-                { id: 'sms', name: 'SMS' },
-            ]}
-            placeholder="All Channels"
+            choices={channelChoices}
+            placeholder="No channel"
             sx={{ width: 300 }}
         />
         <FormInspector name="channels" />
@@ -311,12 +315,8 @@ export const PlaceholderElement = () => (
     <Wrapper>
         <SelectArrayInput
             source="channels"
-            choices={[
-                { id: 'email', name: 'Email' },
-                { id: 'push', name: 'Push Notification' },
-                { id: 'sms', name: 'SMS' },
-            ]}
-            placeholder={<i>All Channels</i>}
+            choices={channelChoices}
+            placeholder={<i>No channel</i>}
             sx={{ width: 300 }}
         />
     </Wrapper>
@@ -326,7 +326,7 @@ export const PlaceholderTranslated = () => (
     <AdminContext
         i18nProvider={polyglotI18nProvider(() => ({
             ...englishMessages,
-            myapp: { channels: { placeholder: 'All Channels' } },
+            myapp: { channels: { placeholder: 'No channel' } },
         }))}
         defaultTheme="light"
     >
@@ -334,11 +334,7 @@ export const PlaceholderTranslated = () => (
             <SimpleForm>
                 <SelectArrayInput
                     source="channels"
-                    choices={[
-                        { id: 'email', name: 'Email' },
-                        { id: 'push', name: 'Push Notification' },
-                        { id: 'sms', name: 'SMS' },
-                    ]}
+                    choices={channelChoices}
                     placeholder="myapp.channels.placeholder"
                     sx={{ width: 300 }}
                 />
@@ -346,6 +342,48 @@ export const PlaceholderTranslated = () => (
         </Create>
     </AdminContext>
 );
+
+export const PlaceholderInFilter = () => {
+    const fakeData = {
+        posts: [
+            { id: 1, title: 'Sunset over the bay', channels: ['email'] },
+            { id: 2, title: 'Ten tips for winter', channels: ['push', 'sms'] },
+            { id: 3, title: 'A tale of two cities', channels: [] },
+        ],
+    };
+    return (
+        <TestMemoryRouter initialEntries={['/posts']}>
+            <AdminContext
+                dataProvider={fakeRestProvider(fakeData, false)}
+                i18nProvider={i18nProvider}
+                defaultTheme="light"
+            >
+                <AdminUI>
+                    <Resource
+                        name="posts"
+                        list={() => (
+                            <List
+                                filters={[
+                                    <SelectArrayInput
+                                        alwaysOn
+                                        key="channels"
+                                        source="channels"
+                                        choices={channelChoices}
+                                        placeholder="All channels"
+                                    />,
+                                ]}
+                            >
+                                <Datagrid>
+                                    <TextField source="title" />
+                                </Datagrid>
+                            </List>
+                        )}
+                    />
+                </AdminUI>
+            </AdminContext>
+        </TestMemoryRouter>
+    );
+};
 
 export const InsideArrayInput = () => (
     <Wrapper>
@@ -393,7 +431,7 @@ const CreateRole = () => {
         <Dialog open onClose={onCancel}>
             <form onSubmit={handleSubmit}>
                 <DialogContent>
-                    <TextField
+                    <MuiTextField
                         label="Role name"
                         value={value}
                         onChange={event => setValue(event.target.value)}

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.stories.tsx
@@ -299,34 +299,34 @@ const channelChoices = [
     { id: 'sms', name: 'SMS' },
 ];
 
-export const Placeholder = () => (
+export const EmptyText = () => (
     <Wrapper>
         <SelectArrayInput
             source="channels"
             choices={channelChoices}
-            placeholder="No channel"
+            emptyText="No channel"
             sx={{ width: 300 }}
         />
         <FormInspector name="channels" />
     </Wrapper>
 );
 
-export const PlaceholderElement = () => (
+export const EmptyTextElement = () => (
     <Wrapper>
         <SelectArrayInput
             source="channels"
             choices={channelChoices}
-            placeholder={<i>No channel</i>}
+            emptyText={<i>No channel</i>}
             sx={{ width: 300 }}
         />
     </Wrapper>
 );
 
-export const PlaceholderTranslated = () => (
+export const EmptyTextTranslated = () => (
     <AdminContext
         i18nProvider={polyglotI18nProvider(() => ({
             ...englishMessages,
-            myapp: { channels: { placeholder: 'No channel' } },
+            myapp: { channels: { none: 'No channel' } },
         }))}
         defaultTheme="light"
     >
@@ -335,7 +335,7 @@ export const PlaceholderTranslated = () => (
                 <SelectArrayInput
                     source="channels"
                     choices={channelChoices}
-                    placeholder="myapp.channels.placeholder"
+                    emptyText="myapp.channels.none"
                     sx={{ width: 300 }}
                 />
             </SimpleForm>
@@ -343,7 +343,7 @@ export const PlaceholderTranslated = () => (
     </AdminContext>
 );
 
-export const PlaceholderInFilter = () => {
+export const EmptyTextInFilter = () => {
     const fakeData = {
         posts: [
             { id: 1, title: 'Sunset over the bay', channels: ['email'] },
@@ -369,7 +369,7 @@ export const PlaceholderInFilter = () => {
                                         key="channels"
                                         source="channels"
                                         choices={channelChoices}
-                                        placeholder="All channels"
+                                        emptyText="All channels"
                                     />,
                                 ]}
                             >

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -4,7 +4,7 @@ import {
     styled,
     useThemeProps,
 } from '@mui/material/styles';
-import { useCallback, useRef, type ChangeEvent } from 'react';
+import { useCallback, useRef, type ChangeEvent, type ReactNode } from 'react';
 import clsx from 'clsx';
 import {
     Select,
@@ -28,6 +28,7 @@ import {
     useGetRecordRepresentation,
     type SupportCreateSuggestionOptions,
     useSupportCreateSuggestion,
+    useTranslate,
 } from 'ra-core';
 import { InputHelperText } from './InputHelperText';
 
@@ -89,6 +90,14 @@ import { Labeled } from '../Labeled';
  *    { id: 'lifestyle', name: 'myroot.tags.lifestyle' },
  *    { id: 'photography', name: 'myroot.tags.photography' },
  * ];
+ *
+ * Use the `placeholder` prop to render a custom text when no choice is selected:
+ * @example
+ * const channelChoices = [
+ *    { id: 'email', name: 'Email' },
+ *    { id: 'push', name: 'Push Notification' },
+ * ];
+ * <SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
  */
 export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     const props = useThemeProps({
@@ -117,6 +126,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
         optionText,
         optionValue = 'id',
         parse,
+        placeholder,
         resource: resourceProp,
         size = 'small',
         source: sourceProp,
@@ -129,6 +139,8 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     } = props;
 
     const inputLabel = useRef(null);
+    const translate = useTranslate();
+    const hasPlaceholder = placeholder != null && placeholder !== '';
 
     const {
         allChoices,
@@ -308,6 +320,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     ref={inputLabel}
                     id={`${id}-outlined-label`}
                     htmlFor={id}
+                    shrink={hasPlaceholder ? true : undefined}
                     {...InputLabelProps}
                 >
                     <FieldTitle
@@ -330,17 +343,30 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     }
                     multiple
                     error={!!fetchError || invalid}
-                    renderValue={(selected: any[]) => (
-                        <div className={SelectArrayInputClasses.chips}>
-                            {(Array.isArray(selected) ? selected : [])
-                                .map(item =>
-                                    (allChoices || []).find(
-                                        // eslint-disable-next-line eqeqeq
-                                        choice => getChoiceValue(choice) == item
-                                    )
+                    displayEmpty={hasPlaceholder ? true : undefined}
+                    renderValue={(selected: any[]) => {
+                        const selectedChoices = (
+                            Array.isArray(selected) ? selected : []
+                        )
+                            .map(item =>
+                                (allChoices || []).find(
+                                    // eslint-disable-next-line eqeqeq
+                                    choice => getChoiceValue(choice) == item
                                 )
-                                .filter(item => !!item)
-                                .map(item => (
+                            )
+                            .filter(item => !!item);
+                        return selectedChoices.length === 0 &&
+                            hasPlaceholder ? (
+                            <span
+                                className={SelectArrayInputClasses.placeholder}
+                            >
+                                {typeof placeholder === 'string'
+                                    ? translate(placeholder, { _: placeholder })
+                                    : placeholder}
+                            </span>
+                        ) : (
+                            <div className={SelectArrayInputClasses.chips}>
+                                {selectedChoices.map(item => (
                                     <Chip
                                         key={getChoiceValue(item)}
                                         label={renderMenuItemOption(item)}
@@ -348,8 +374,9 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                                         size="small"
                                     />
                                 ))}
-                        </div>
-                    )}
+                            </div>
+                        );
+                    }}
                     disabled={disabled || readOnly}
                     readOnly={readOnly}
                     data-testid="selectArray"
@@ -379,9 +406,13 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
 export type SelectArrayInputProps = ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &
     Omit<CommonInputProps, 'source'> &
-    Omit<FormControlProps, 'defaultValue' | 'onBlur' | 'onChange'> & {
+    Omit<
+        FormControlProps,
+        'defaultValue' | 'onBlur' | 'onChange' | 'placeholder'
+    > & {
         options?: SelectProps;
         InputLabelProps?: Omit<InputLabelProps, 'htmlFor' | 'id' | 'ref'>;
+        placeholder?: ReactNode;
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
     };
@@ -429,6 +460,7 @@ const PREFIX = 'RaSelectArrayInput';
 export const SelectArrayInputClasses = {
     chips: `${PREFIX}-chips`,
     chip: `${PREFIX}-chip`,
+    placeholder: `${PREFIX}-placeholder`,
 };
 
 const StyledFormControl = styled(FormControl, {
@@ -448,13 +480,17 @@ const StyledFormControl = styled(FormControl, {
         marginTop: theme.spacing(0.5),
         marginRight: theme.spacing(0.5),
     },
+
+    [`& .${SelectArrayInputClasses.placeholder}`]: {
+        color: (theme.vars || theme).palette.text.secondary,
+    },
 }));
 
 const defaultOptions = {};
 
 declare module '@mui/material/styles' {
     interface ComponentNameToClassKey {
-        RaSelectArrayInput: 'root' | 'chips' | 'chip';
+        RaSelectArrayInput: 'root' | 'chips' | 'chip' | 'placeholder';
     }
 
     interface ComponentsPropsList {

--- a/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
+++ b/packages/ra-ui-materialui/src/input/SelectArrayInput.tsx
@@ -91,13 +91,13 @@ import { Labeled } from '../Labeled';
  *    { id: 'photography', name: 'myroot.tags.photography' },
  * ];
  *
- * Use the `placeholder` prop to render a custom text when no choice is selected:
+ * Use the `emptyText` prop to render a custom text when no choice is selected:
  * @example
  * const channelChoices = [
  *    { id: 'email', name: 'Email' },
  *    { id: 'push', name: 'Push Notification' },
  * ];
- * <SelectArrayInput source="channels" choices={channelChoices} placeholder={<i>All Channels</i>} />
+ * <SelectArrayInput source="channels" choices={channelChoices} emptyText={<i>No channel</i>} />
  */
 export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
     const props = useThemeProps({
@@ -111,6 +111,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
         createLabel,
         createValue,
         disableValue = 'disabled',
+        emptyText,
         format,
         helperText,
         label,
@@ -126,7 +127,6 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
         optionText,
         optionValue = 'id',
         parse,
-        placeholder,
         resource: resourceProp,
         size = 'small',
         source: sourceProp,
@@ -140,7 +140,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
 
     const inputLabel = useRef(null);
     const translate = useTranslate();
-    const hasPlaceholder = placeholder != null && placeholder !== '';
+    const hasEmptyText = emptyText != null && emptyText !== '';
 
     const {
         allChoices,
@@ -320,7 +320,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     ref={inputLabel}
                     id={`${id}-outlined-label`}
                     htmlFor={id}
-                    shrink={hasPlaceholder ? true : undefined}
+                    shrink={hasEmptyText ? true : undefined}
                     {...InputLabelProps}
                 >
                     <FieldTitle
@@ -343,7 +343,7 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                     }
                     multiple
                     error={!!fetchError || invalid}
-                    displayEmpty={hasPlaceholder ? true : undefined}
+                    displayEmpty={hasEmptyText ? true : undefined}
                     renderValue={(selected: any[]) => {
                         const selectedChoices = (
                             Array.isArray(selected) ? selected : []
@@ -355,14 +355,11 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
                                 )
                             )
                             .filter(item => !!item);
-                        return selectedChoices.length === 0 &&
-                            hasPlaceholder ? (
-                            <span
-                                className={SelectArrayInputClasses.placeholder}
-                            >
-                                {typeof placeholder === 'string'
-                                    ? translate(placeholder, { _: placeholder })
-                                    : placeholder}
+                        return selectedChoices.length === 0 && hasEmptyText ? (
+                            <span className={SelectArrayInputClasses.emptyText}>
+                                {typeof emptyText === 'string'
+                                    ? translate(emptyText, { _: emptyText })
+                                    : emptyText}
                             </span>
                         ) : (
                             <div className={SelectArrayInputClasses.chips}>
@@ -406,13 +403,10 @@ export const SelectArrayInput = (inProps: SelectArrayInputProps) => {
 export type SelectArrayInputProps = ChoicesProps &
     Omit<SupportCreateSuggestionOptions, 'handleChange'> &
     Omit<CommonInputProps, 'source'> &
-    Omit<
-        FormControlProps,
-        'defaultValue' | 'onBlur' | 'onChange' | 'placeholder'
-    > & {
+    Omit<FormControlProps, 'defaultValue' | 'onBlur' | 'onChange'> & {
+        emptyText?: ReactNode;
         options?: SelectProps;
         InputLabelProps?: Omit<InputLabelProps, 'htmlFor' | 'id' | 'ref'>;
-        placeholder?: ReactNode;
         source?: string;
         onChange?: (event: ChangeEvent<HTMLInputElement> | RaRecord) => void;
     };
@@ -460,7 +454,7 @@ const PREFIX = 'RaSelectArrayInput';
 export const SelectArrayInputClasses = {
     chips: `${PREFIX}-chips`,
     chip: `${PREFIX}-chip`,
-    placeholder: `${PREFIX}-placeholder`,
+    emptyText: `${PREFIX}-emptyText`,
 };
 
 const StyledFormControl = styled(FormControl, {
@@ -481,7 +475,7 @@ const StyledFormControl = styled(FormControl, {
         marginRight: theme.spacing(0.5),
     },
 
-    [`& .${SelectArrayInputClasses.placeholder}`]: {
+    [`& .${SelectArrayInputClasses.emptyText}`]: {
         color: (theme.vars || theme).palette.text.secondary,
     },
 }));
@@ -490,7 +484,7 @@ const defaultOptions = {};
 
 declare module '@mui/material/styles' {
     interface ComponentNameToClassKey {
-        RaSelectArrayInput: 'root' | 'chips' | 'chip' | 'placeholder';
+        RaSelectArrayInput: 'root' | 'chips' | 'chip' | 'emptyText';
     }
 
     interface ComponentsPropsList {


### PR DESCRIPTION
Closes #10454.

# Problem

`<SelectArrayInput>` cannot render a custom text when no choice is selected (e.g. "All Channels" in a filter).

## Solution

Add a `placeholder` prop, rendered in place of the chips while the value is empty.

## How To Test

http://localhost:9010/?path=/story/ra-ui-materialui-input-selectarrayinput--placeholder

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
