### PR TITLE
Fix "Maximum update depth exceeded" when many ReferenceFields resolve at once

### DIFF
--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.spec.tsx
@@ -536,4 +536,104 @@ describe('useGetManyAggregate', () => {
             expect(abort).toHaveBeenCalled();
         });
     });
+    it('should resolve all the aggregated calls in a single React commit', async () => {
+        // Each aggregated call belongs to a distinct useQuery, so resolving them one
+        // by one makes React commit each of them separately. A child updating its
+        // state during the commit phase (like an avatar reporting its image loading
+        // status from a layout effect) then turns those commits into nested updates
+        // instead of batched ones, and React throws "Maximum update depth exceeded"
+        // past 50 of them.
+        // See https://github.com/marmelab/react-admin/issues/11324
+        const CONSUMERS = 30;
+        let commits = 0;
+        const commitsWithNewData: number[] = [];
+
+        // updates its state during the commit phase, like Base UI's Avatar.Image
+        const CommitPhaseChild = () => {
+            const [status, setStatus] = React.useState('idle');
+            React.useLayoutEffect(() => {
+                setStatus('loaded');
+            }, []);
+            return <span>{status}</span>;
+        };
+
+        const Consumer = ({ id }: { id: number }) => {
+            const { data } = useGetManyAggregate('posts', { ids: [id] });
+            const hadData = React.useRef(false);
+            React.useLayoutEffect(() => {
+                if (data && !hadData.current) {
+                    hadData.current = true;
+                    commitsWithNewData.push(commits);
+                }
+            });
+            return data ? <CommitPhaseChild /> : <span>pending</span>;
+        };
+
+        const dataProviderWithManyRecords = testDataProvider({
+            getMany: jest.fn((_resource, { ids }) =>
+                Promise.resolve({
+                    data: ids.map(id => ({ id, title: `post ${id}` })),
+                })
+            ) as any,
+        });
+        render(
+            <CoreAdminContext dataProvider={dataProviderWithManyRecords}>
+                <React.Profiler id="consumers" onRender={() => commits++}>
+                    {Array.from({ length: CONSUMERS }, (_, index) => (
+                        <Consumer key={index} id={index + 1} />
+                    ))}
+                </React.Profiler>
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(commitsWithNewData).toHaveLength(CONSUMERS);
+        });
+        expect(dataProviderWithManyRecords.getMany).toHaveBeenCalledTimes(1);
+        expect(new Set(commitsWithNewData).size).toBe(1);
+    });
+    it('should not repopulate the cache of a query canceled while the request is in flight', async () => {
+        let resolveGetMany: (value: any) => void = () => undefined;
+        const dataProvider = testDataProvider({
+            getMany: jest.fn(
+                () =>
+                    new Promise(resolve => {
+                        resolveGetMany = resolve;
+                    })
+            ) as any,
+        });
+        const queryClient = new QueryClient();
+        render(
+            <CoreAdminContext
+                dataProvider={dataProvider}
+                queryClient={queryClient}
+            >
+                <UseGetManyAggregate resource="posts" ids={[1]} />
+                <UseGetManyAggregate resource="posts" ids={[2]} />
+            </CoreAdminContext>
+        );
+        await waitFor(() => {
+            expect(dataProvider.getMany).toHaveBeenCalledTimes(1);
+        });
+        // cancel one of the two pending calls, not the aggregated request
+        await queryClient.cancelQueries({
+            queryKey: ['posts', 'getMany', { ids: ['1'] }],
+            exact: true,
+        });
+        resolveGetMany({
+            data: [
+                { id: 1, title: 'foo' },
+                { id: 2, title: 'bar' },
+            ],
+        });
+        // the call that was not canceled still gets its data
+        await waitFor(() => {
+            expect(
+                queryClient.getQueryData(['posts', 'getMany', { ids: ['2'] }])
+            ).toEqual([{ id: 2, title: 'bar' }]);
+        });
+        // the canceled one is left alone
+        expect(
+            queryClient.getQueryData(['posts', 'getMany', { ids: ['1'] }])
+        ).toBeUndefined();
+    });
 });

--- a/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
+++ b/packages/ra-core/src/dataProvider/useGetManyAggregate.ts
@@ -1,6 +1,8 @@
 import { useEffect, useMemo, useRef } from 'react';
 import {
+    notifyManager,
     QueryClient,
+    QueryKey,
     useQueryClient,
     useQuery,
     UseQueryOptions,
@@ -123,6 +125,7 @@ export const useGetManyAggregate = <
                     resource,
                     ids,
                     meta,
+                    queryKey: queryParams.queryKey,
                     resolve,
                     reject,
                     dataProvider,
@@ -228,12 +231,57 @@ interface GetManyCallArgs {
     resource: string;
     ids: Identifier[];
     meta?: any;
+    queryKey: QueryKey;
     resolve: (data: any[]) => void;
     reject: (error?: any) => void;
     dataProvider: DataProvider;
     queryClient: QueryClient;
     signal?: AbortSignal;
 }
+
+/**
+ * Resolve all the pending calls with the data they requested, in a single React update.
+ *
+ * Each pending call belongs to a distinct useQuery. Resolving a promise only makes
+ * its query transition two microtasks later, long after any synchronous
+ * notifyManager transaction has closed, so resolving the calls one by one makes
+ * react-query flush one observer notification per call, and React commits each of
+ * them separately. Any child updating its state during the commit phase (e.g. an
+ * avatar reporting its image loading status from a layout effect) then turns those
+ * commits into nested updates instead of batched ones, and React throws
+ * "Maximum update depth exceeded" past 50 of them.
+ *
+ * Writing the data of every pending call inside a single notifyManager transaction
+ * makes react-query flush all the observer notifications at once, so all the
+ * consumers get their data in one commit. The calls are then resolved to let their
+ * query leave the fetching state.
+ */
+const resolveCallsWithData = (
+    calls: GetManyCallArgs[],
+    queryClient: QueryClient,
+    getDataForCall: (call: GetManyCallArgs) => any[]
+) => {
+    const resolutions = calls.map(call => ({
+        call,
+        data: getDataForCall(call),
+    }));
+    notifyManager.batch(() => {
+        resolutions.forEach(({ call, data }) => {
+            const query = queryClient
+                .getQueryCache()
+                .find({ queryKey: call.queryKey, exact: true });
+            // don't resurrect a query that was canceled or removed in the meantime
+            if (query?.state.fetchStatus !== 'fetching') return;
+            queryClient.setQueryData(call.queryKey, data);
+        });
+    });
+    resolutions.forEach(({ call, data }) => call.resolve(data));
+};
+
+const filterDataForCall = (data: any[]) => (call: GetManyCallArgs) =>
+    data.filter(record =>
+        call.ids.map(id => String(id)).includes(String(record.id))
+    );
 
 /**
  * Group and execute all calls to the dataProvider.getMany() method for the current tick
@@ -293,9 +341,7 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
 
         if (aggregatedIds.length === 0) {
             // no need to call the data provider if all the ids are null
-            callsForResource.forEach(({ resolve }) => {
-                resolve([]);
-            });
+            resolveCallsWithData(callsForResource, queryClient, () => []);
             return;
         }
 
@@ -317,15 +363,11 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
                 .then(
                     data => {
                         // We must then resolve all the pending calls with the data they requested
-                        callsForResource.forEach(({ ids, resolve }) => {
-                            resolve(
-                                data.filter(record =>
-                                    ids
-                                        .map(id => String(id))
-                                        .includes(String(record.id))
-                                )
-                            );
-                        });
+                        resolveCallsWithData(
+                            callsForResource,
+                            queryClient,
+                            filterDataForCall(data)
+                        );
                     },
                     error => {
                         // All pending calls must also receive the error
@@ -364,15 +406,11 @@ const callGetManyQueries = batch((calls: GetManyCallArgs[]) => {
                         .then(({ data }) => data),
             })
             .then(data => {
-                callsForResource.forEach(({ ids, resolve }) => {
-                    resolve(
-                        data.filter(record =>
-                            ids
-                                .map(id => String(id))
-                                .includes(String(record.id))
-                        )
-                    );
-                });
+                resolveCallsWithData(
+                    callsForResource,
+                    queryClient,
+                    filterDataForCall(data)
+                );
             })
             .catch(error =>
                 callsForResource.forEach(({ reject }) => reject(error))


### PR DESCRIPTION
## Problem

A page with enough `<ReferenceField>` throws and takes the page down:

```
Maximum update depth exceeded. This can happen when a component repeatedly calls
setState inside componentWillUpdate or componentDidUpdate. React limits the number
of nested updates to prevent infinite loops.
```

`useGetManyAggregate` aggregates the *requests* but not the *resolutions*: it resolves its pending calls one at a time, and since each belongs to a distinct `useQuery`, React commits each consumer separately. When a child updates its state during the commit phase (from a layout effect), those commits nest instead of batching, and past 50 React throws. Measured on the shadcn-admin-kit dashboard, one `ReferenceField` and one Base UI avatar per row: 25 rows pass, 35 throw. It affects every consumer of the hook: `<ReferenceField>`, `<ReferenceInput>`, `<ReferenceManyField>`, `<ReferenceArrayField>`, `<AutocompleteInput>` with a reference.

## Solution

Write the data of all pending calls with `queryClient.setQueryData` inside a single `notifyManager.batch`, then resolve them as before to let their query leave the fetching state. Those writes are synchronous, so every dispatch stays in one transaction: react-query flushes all the observer notifications at once and all the consumers render in one commit. Wrapping the resolution loop in `notifyManager.batch` cannot work, because a resolved promise only makes its query transition two microtasks later, once the synchronous transaction is closed.

Calls whose query was canceled or removed while the request was in flight are skipped, so their cache entry is not resurrected. No public API change, no new option, aggregation untouched.

It also makes reference lists cheaper. 100 rows with one `ReferenceField` each (Chromium, React 19, median of 5 runs): commits 101 → 2, wall clock 205 → 160 ms, and no extra render (200 row renders before and after). That count is 2 rather than 3 because react-query flushes notifications on a `setTimeout(0)`, after both dispatches, so the intermediate state (data present, `isFetching` still `true`) goes unobserved; a microtask flush would make it observable.

## How To Test

Two tests added to `useGetManyAggregate.spec.tsx`: one asserts that all the aggregated calls resolve in a single React commit (before the fix: `Expected: 1, Received: 30`), the other that a query canceled mid-flight is not repopulated (fails without the guard, with `Received: [{"id": 1, "title": "foo"}]`).

The overflow itself is not reproducible in this repo, so it was verified against a real app. React 18.3.1 only counts a pending `SyncLane` at the end of a commit while React 19.1.0 also counts `Default` (`remainingLanes & 42`), and under React 18 even 200 consumers with a three-deep chain of commit-phase updates give 601 commits and no error. On shadcn-admin-kit `test-base-ui-no-compat` with `PendingReviews` uncapped to 61 rows, headless Chromium, React 19: 3 runs out of 3 throw with ra-core 5.14.3, 0 out of 3 with this branch, and the reference-heavy screens (`#/reviews`, `#/orders`, `#/customers`, `#/orders/1`, `#/customers/1`) render with zero console errors.

All green: `ra-core` 1309 tests, whole monorepo 2839 tests, including in the mode CI uses (`jest --runInBand`, Node 22.x).

Known limits: the error path is still resolved one call at a time, because there is no public equivalent of `setQueryData` for an error state; there is no React 19 test in this repo; and the cascade stays reachable whenever one commit per row is obtained some other way, so this fixes the reliable case rather than removing the class of problem.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [ ] The PR includes one or several **stories** (if not possible, describe why) — no story: the change is internal to a headless hook and adds no UI state, and reproducing it visually needs ~35 rows plus a child updating state during commit
- [ ] The **documentation** is up to date — no doc change: no public API, option or return value changes
