### PR TITLE
[Demo] Upgrade Echarts to v6

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -11,7 +11,7 @@
         "clsx": "^2.1.1",
         "data-generator-retail": "^5.0.0",
         "date-fns": "^3.6.0",
-        "echarts": "^5.6.0",
+        "echarts": "^6.1.0",
         "fakerest": "^4.2.0",
         "graphql": "^15.6.0",
         "graphql-tag": "^2.12.6",

--- a/examples/demo/src/dashboard/OrderChart.tsx
+++ b/examples/demo/src/dashboard/OrderChart.tsx
@@ -142,7 +142,6 @@ const OrderChart = (props: { orders?: Order[] }) => {
                     right: '1%',
                     bottom: '0%',
                     top: '2%',
-                    containLabel: true,
                 },
                 series: [
                     {

--- a/packages/ra-core/package.json
+++ b/packages/ra-core/package.json
@@ -47,7 +47,6 @@
         "@types/node": "^20.10.7",
         "@types/node-polyglot": "^0.4.31",
         "@types/react": "^18.3.3",
-        "echarts": "^5.6.0",
         "expect": "^27.4.6",
         "ignore-styles": "~5.0.1",
         "jscodeshift": "^0.15.2",

--- a/packages/ra-core/src/controller/list/WithListContext.stories.tsx
+++ b/packages/ra-core/src/controller/list/WithListContext.stories.tsx
@@ -1,6 +1,4 @@
 import * as React from 'react';
-import * as echarts from 'echarts';
-import { useEffect, useRef } from 'react';
 import fakerestDataProvider from 'ra-data-fakerest';
 
 import { ListBase } from './ListBase';
@@ -167,53 +165,116 @@ export const Basic = () => (
     </CoreAdminContext>
 );
 
-const LineChart = ({ data }) => {
-    const chartRef = useRef(null);
-    useEffect(() => {
-        if (!data) return;
-        const chartInstance = echarts.init(chartRef.current);
+const SERIES = [
+    { name: 'Apples', field: 'apples', color: '#2a78d6' },
+    { name: 'Blueberries', field: 'blueberries', color: '#eb6834' },
+    { name: 'Carrots', field: 'carrots', color: '#1baf7a' },
+] as const;
 
-        const option = {
-            tooltip: {
-                trigger: 'axis',
-            },
-            legend: {
-                data: ['Apples', 'Blueberries', 'Carrots'],
-            },
-            xAxis: {
-                type: 'category',
-                data: data.map(fruit => fruit.date),
-            },
-            yAxis: {
-                type: 'value',
-            },
-            series: [
-                {
-                    name: 'Apples',
-                    type: 'line',
-                    data: data.map(fruit => fruit.apples),
-                },
-                {
-                    name: 'Blueberries',
-                    type: 'line',
-                    data: data.map(fruit => fruit.blueberries),
-                },
-                {
-                    name: 'Carrots',
-                    type: 'line',
-                    data: data.map(fruit => fruit.carrots),
-                },
-            ],
-        };
+const MONTHS = [
+    'Jan',
+    'Feb',
+    'Mar',
+    'Apr',
+    'May',
+    'Jun',
+    'Jul',
+    'Aug',
+    'Sep',
+    'Oct',
+    'Nov',
+    'Dec',
+];
 
-        chartInstance.setOption(option);
+const WIDTH = 700;
+const HEIGHT = 300;
+const MARGIN = { top: 16, right: 96, bottom: 28, left: 32 };
 
-        return () => {
-            chartInstance.dispose();
-        };
-    }, [data]);
+const LineChart = ({ data }: { data?: Fruit[] }) => {
+    if (!data || data.length < 2) return null;
 
-    return <div ref={chartRef} style={{ height: 300, width: 700 }} />;
+    const innerWidth = WIDTH - MARGIN.left - MARGIN.right;
+    const innerHeight = HEIGHT - MARGIN.top - MARGIN.bottom;
+    const maxValue = Math.max(
+        ...data.flatMap(fruit => SERIES.map(series => fruit[series.field]))
+    );
+    const yMax = Math.ceil(maxValue / 5) * 5;
+    const yTicks = Array.from({ length: yMax / 5 + 1 }, (_, i) => i * 5);
+    const x = (index: number) =>
+        MARGIN.left + (index * innerWidth) / (data.length - 1);
+    const y = (value: number) => MARGIN.top + innerHeight * (1 - value / yMax);
+
+    return (
+        <svg
+            width={WIDTH}
+            height={HEIGHT}
+            role="img"
+            aria-label="Fruit prices over time"
+            style={{ fontFamily: 'system-ui, sans-serif' }}
+        >
+            {yTicks.map(tick => (
+                <g key={tick}>
+                    <line
+                        x1={MARGIN.left}
+                        x2={WIDTH - MARGIN.right}
+                        y1={y(tick)}
+                        y2={y(tick)}
+                        stroke={tick === 0 ? '#c3c2b7' : '#e1e0d9'}
+                    />
+                    <text
+                        x={MARGIN.left - 8}
+                        y={y(tick)}
+                        textAnchor="end"
+                        dominantBaseline="middle"
+                        fontSize={11}
+                        fill="#898781"
+                    >
+                        {tick}
+                    </text>
+                </g>
+            ))}
+            {data.map((fruit, index) =>
+                fruit.date.endsWith('-01') ? (
+                    <text
+                        key={fruit.date}
+                        x={x(index)}
+                        y={HEIGHT - 8}
+                        textAnchor="middle"
+                        fontSize={11}
+                        fill="#898781"
+                    >
+                        {MONTHS[parseInt(fruit.date.slice(5, 7), 10) - 1]}
+                    </text>
+                ) : null
+            )}
+            {SERIES.map(series => (
+                <g key={series.name}>
+                    <path
+                        d={data
+                            .map(
+                                (fruit, index) =>
+                                    `${index === 0 ? 'M' : 'L'}${x(index)},${y(fruit[series.field])}`
+                            )
+                            .join(' ')}
+                        fill="none"
+                        stroke={series.color}
+                        strokeWidth={2}
+                        strokeLinejoin="round"
+                        strokeLinecap="round"
+                    />
+                    <text
+                        x={x(data.length - 1) + 8}
+                        y={y(data[data.length - 1][series.field])}
+                        dominantBaseline="middle"
+                        fontSize={12}
+                        fill="#52514e"
+                    >
+                        {series.name}
+                    </text>
+                </g>
+            ))}
+        </svg>
+    );
 };
 
 export const Chart = () => (

--- a/yarn.lock
+++ b/yarn.lock
@@ -10855,7 +10855,7 @@ __metadata:
     clsx: "npm:^2.1.1"
     data-generator-retail: "npm:^5.0.0"
     date-fns: "npm:^3.6.0"
-    echarts: "npm:^5.6.0"
+    echarts: "npm:^6.1.0"
     fakerest: "npm:^4.2.0"
     graphql: "npm:^15.6.0"
     graphql-tag: "npm:^2.12.6"
@@ -11184,13 +11184,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"echarts@npm:^5.6.0":
-  version: 5.6.0
-  resolution: "echarts@npm:5.6.0"
+"echarts@npm:^6.1.0":
+  version: 6.1.0
+  resolution: "echarts@npm:6.1.0"
   dependencies:
     tslib: "npm:2.3.0"
-    zrender: "npm:5.6.1"
-  checksum: 6d6a2ee88534d1ff0433e935c542237b9896de1c94959f47ebc7e0e9da26f59bf11c91ed6fc135b62ad2786c779ee12bc536fa481e60532dad5b6a2f5167e9ea
+    zrender: "npm:6.1.0"
+  checksum: a0911a9d75969ff946d0bce998e95e1924cdec7f5ca6be13ded376e2a47067c70b264ee8d04ba84345aa7895363e202f54c87d2bae114859bd154d565babc09c
   languageName: node
   linkType: hard
 
@@ -25862,12 +25862,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"zrender@npm:5.6.1":
-  version: 5.6.1
-  resolution: "zrender@npm:5.6.1"
+"zrender@npm:6.1.0":
+  version: 6.1.0
+  resolution: "zrender@npm:6.1.0"
   dependencies:
     tslib: "npm:2.3.0"
-  checksum: dc1cc570054640cbd8fbb7b92e6252f225319522bfe3e8dc8bf02cc02d414e00a4c8d0a6f89bfc9d96e5e9511fdca94dd3d06bf53690df2b2f12b0fc560ac307
+  checksum: bfdb5e2ccd70893a9e2c7f33959749a6a1abc8912c2b1af301a05593d677a2f6f6087cdc4f0bf73883b99eea2f2d11d1922c71c3bf0bd4e9e5b362fd32129bce
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -20343,7 +20343,6 @@ __metadata:
     "@types/node-polyglot": "npm:^0.4.31"
     "@types/react": "npm:^18.3.3"
     date-fns: "npm:^3.6.0"
-    echarts: "npm:^5.6.0"
     eventemitter3: "npm:^5.0.1"
     expect: "npm:^27.4.6"
     ignore-styles: "npm:~5.0.1"


### PR DESCRIPTION
## Problem

Echarts v5 has some security vulnerabilities. Dependabot raises alerts for them, even though we only use it in the demo. 

## Solution

Upgrade it to v6 and remove it from ra-core, where it's only used in a story. 

## How To Test

- launch the demo and check that the chart renders properly on the dashboard
- launch the storybook and check that the chart appears correctly in http://localhost:9010/?path=/story/ra-core-controller-list-withlistcontext--chart

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- ~~[ ] The PR includes **unit tests**~~
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

