### PR TITLE
Revert "[TypeScript] Fix default Error type for data provider hooks"

### DIFF
--- a/docs/useCreate.md
+++ b/docs/useCreate.md
@@ -326,7 +326,7 @@ const createPost = async () => {
 
 ## TypeScript
 
-The `useCreate` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useCreate` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 type Product = {

--- a/docs/useDelete.md
+++ b/docs/useDelete.md
@@ -68,7 +68,7 @@ const DeleteButton = () => {
 
 ## TypeScript
 
-The `useDelete` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useDelete` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useDelete<Product, Error>(undefined, undefined, {

--- a/docs/useDeleteMany.md
+++ b/docs/useDeleteMany.md
@@ -67,7 +67,7 @@ const BulkDeletePostsButton = () => {
 
 ## TypeScript
 
-The `useDeleteMany` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useDeleteMany` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useDeleteMany<Product, Error>(undefined, undefined, {

--- a/docs/useUpdateMany.md
+++ b/docs/useUpdateMany.md
@@ -68,7 +68,7 @@ const BulkResetViewsButton = () => {
 
 ## TypeScript
 
-The `useUpdateMany` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useUpdateMany` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useUpdateMany<Product, Error>(undefined, undefined, {

--- a/docs_headless/src/content/docs/useCreate.md
+++ b/docs_headless/src/content/docs/useCreate.md
@@ -328,7 +328,7 @@ const createPost = async () => {
 
 ## TypeScript
 
-The `useCreate` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useCreate` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 type Product = {

--- a/docs_headless/src/content/docs/useDelete.md
+++ b/docs_headless/src/content/docs/useDelete.md
@@ -64,7 +64,7 @@ const DeleteButton = () => {
 
 ## TypeScript
 
-The `useDelete` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useDelete` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useDelete<Product, Error>(undefined, undefined, {

--- a/docs_headless/src/content/docs/useDeleteMany.md
+++ b/docs_headless/src/content/docs/useDeleteMany.md
@@ -64,7 +64,7 @@ const BulkDeletePostsButton = () => {
 
 ## TypeScript
 
-The `useDeleteMany` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useDeleteMany` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useDeleteMany<Product, Error>(undefined, undefined, {

--- a/docs_headless/src/content/docs/useUpdateMany.md
+++ b/docs_headless/src/content/docs/useUpdateMany.md
@@ -64,7 +64,7 @@ const BulkResetViewsButton = () => {
 
 ## TypeScript
 
-The `useUpdateMany` hook accepts a generic parameter for the record type and another for the error type (which defaults to `Error`):
+The `useUpdateMany` hook accepts a generic parameter for the record type and another for the error type:
 
 ```tsx
 useUpdateMany<Product, Error>(undefined, undefined, {

--- a/packages/ra-core/src/controller/button/useBulkDeleteController.ts
+++ b/packages/ra-core/src/controller/button/useBulkDeleteController.ts
@@ -102,7 +102,7 @@ export const useBulkDeleteController = <
 
 export interface UseBulkDeleteControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > {
     mutationMode?: MutationMode;
     mutationOptions?: UseDeleteManyOptions<RecordType, MutationOptionsError>;

--- a/packages/ra-core/src/controller/button/useBulkUpdateController.tsx
+++ b/packages/ra-core/src/controller/button/useBulkUpdateController.tsx
@@ -113,7 +113,7 @@ export const useBulkUpdateController = <
 
 export interface UseBulkUpdateControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > {
     /* @deprecated use mutationOptions instead */
     onSuccess?: () => void;

--- a/packages/ra-core/src/controller/button/useDeleteController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteController.tsx
@@ -164,7 +164,7 @@ export const useDeleteController = <
 
 export interface UseDeleteControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > {
     mutationMode?: MutationMode;
     mutationOptions?: UseDeleteOptions<RecordType, MutationOptionsError>;

--- a/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithConfirmController.tsx
@@ -173,7 +173,7 @@ const useDeleteWithConfirmController = <
 
 export interface UseDeleteWithConfirmControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends UseDeleteControllerParams<RecordType, MutationOptionsError> {
     onClick?: ReactEventHandler<any>;
 }

--- a/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
+++ b/packages/ra-core/src/controller/button/useDeleteWithUndoController.tsx
@@ -68,7 +68,7 @@ const useDeleteWithUndoController = <
 
 export interface UseDeleteWithUndoControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends Omit<
         UseDeleteControllerParams<RecordType, MutationOptionsError>,
         'mutationMode'

--- a/packages/ra-core/src/controller/button/useUpdateController.tsx
+++ b/packages/ra-core/src/controller/button/useUpdateController.tsx
@@ -148,7 +148,7 @@ export const useUpdateController = <
 
 export interface UseUpdateControllerParams<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > {
     mutationMode?: MutationMode;
     mutationOptions?: UseUpdateOptions<RecordType, MutationOptionsError>;

--- a/packages/ra-core/src/dataProvider/useCreate.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useCreate.spec.tsx
@@ -728,20 +728,3 @@ describe('useCreate', () => {
         await screen.findByText('3: New Post');
     });
 });
-
-/**
- * Type-level check: the error type defaults to Error, so callbacks don't
- * require a cast. See https://github.com/marmelab/react-admin/issues/11262
- */
-const _useCreateErrorTypeCheck = () => {
-    const [create] = useCreate<{ title: string }>();
-    create(
-        'posts',
-        { data: { title: 'Hello' } },
-        { onError: error => error.message }
-    );
-    useCreate<{ title: string }>('posts', undefined, {
-        onError: error => error.message,
-        onSettled: (_data, error) => error?.message,
-    });
-};

--- a/packages/ra-core/src/dataProvider/useCreate.ts
+++ b/packages/ra-core/src/dataProvider/useCreate.ts
@@ -80,7 +80,7 @@ import {
  */
 export const useCreate = <
     RecordType extends Omit<RaRecord, 'id'> = any,
-    MutationError = Error,
+    MutationError = unknown,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier },
 >(
     resource?: string,
@@ -279,7 +279,7 @@ export interface UseCreateMutateParams<
 
 export type UseCreateOptions<
     RecordType extends Omit<RaRecord, 'id'> = any,
-    MutationError = Error,
+    MutationError = unknown,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier },
 > = Omit<
     UseMutationOptions<
@@ -307,7 +307,7 @@ export type UseCreateOptions<
 export type CreateMutationFunction<
     RecordType extends Omit<RaRecord, 'id'> = any,
     TReturnPromise extends boolean = boolean,
-    MutationError = Error,
+    MutationError = unknown,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier },
 > = (
     resource?: string,
@@ -323,7 +323,7 @@ export type CreateMutationFunction<
 export type UseCreateResult<
     RecordType extends Omit<RaRecord, 'id'> = any,
     TReturnPromise extends boolean = boolean,
-    MutationError = Error,
+    MutationError = unknown,
     ResultRecordType extends RaRecord = RecordType & { id: Identifier },
 > = [
     CreateMutationFunction<

--- a/packages/ra-core/src/dataProvider/useDelete.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDelete.spec.tsx
@@ -854,16 +854,3 @@ describe('useDelete', () => {
         });
     });
 });
-
-/**
- * Type-level check: the error type defaults to Error, so callbacks don't
- * require a cast. See https://github.com/marmelab/react-admin/issues/11262
- */
-const _useDeleteErrorTypeCheck = () => {
-    const [deleteOne] = useDelete<{ id: number }>();
-    deleteOne('posts', { id: 1 }, { onError: error => error.message });
-    useDelete<{ id: number }>('posts', undefined, {
-        onError: error => error.message,
-        onSettled: (_data, error) => error?.message,
-    });
-};

--- a/packages/ra-core/src/dataProvider/useDelete.ts
+++ b/packages/ra-core/src/dataProvider/useDelete.ts
@@ -82,7 +82,7 @@ import { useEvent } from '../util';
  */
 export const useDelete = <
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
 >(
     resource?: string,
     params: Partial<DeleteParams<RecordType>> = {},
@@ -286,7 +286,7 @@ export interface UseDeleteMutateParams<RecordType extends RaRecord = any> {
 
 export type UseDeleteOptions<
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
 > = Omit<
     UseMutationOptions<
         RecordType,
@@ -304,7 +304,7 @@ export type UseDeleteOptions<
 
 export type UseDeleteResult<
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
     TReturnPromise extends boolean = boolean,
 > = [
     (

--- a/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.spec.tsx
@@ -465,16 +465,3 @@ describe('useDeleteMany', () => {
         });
     });
 });
-
-/**
- * Type-level check: the error type defaults to Error, so callbacks don't
- * require a cast. See https://github.com/marmelab/react-admin/issues/11262
- */
-const _useDeleteManyErrorTypeCheck = () => {
-    const [deleteMany] = useDeleteMany<{ id: number }>();
-    deleteMany('posts', { ids: [1] }, { onError: error => error.message });
-    useDeleteMany<{ id: number }>('posts', undefined, {
-        onError: error => error.message,
-        onSettled: (_data, error) => error?.message,
-    });
-};

--- a/packages/ra-core/src/dataProvider/useDeleteMany.ts
+++ b/packages/ra-core/src/dataProvider/useDeleteMany.ts
@@ -82,7 +82,7 @@ import {
  */
 export const useDeleteMany = <
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
 >(
     resource?: string,
     params: Partial<DeleteManyParams<RecordType>> = {},
@@ -309,7 +309,7 @@ export interface UseDeleteManyMutateParams<RecordType extends RaRecord = any> {
 
 export type UseDeleteManyOptions<
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
     TReturnPromise extends boolean = boolean,
 > = Omit<
     UseMutationOptions<
@@ -328,7 +328,7 @@ export type UseDeleteManyOptions<
 
 export type UseDeleteManyResult<
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
     TReturnPromise extends boolean = boolean,
 > = [
     (

--- a/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.spec.tsx
@@ -788,20 +788,3 @@ describe('useUpdateMany', () => {
 afterEach(() => {
     jest.restoreAllMocks();
 });
-
-/**
- * Type-level check: the error type defaults to Error, so callbacks don't
- * require a cast. See https://github.com/marmelab/react-admin/issues/11262
- */
-const _useUpdateManyErrorTypeCheck = () => {
-    const [updateMany] = useUpdateMany<{ id: number; title: string }>();
-    updateMany(
-        'posts',
-        { ids: [1], data: { title: 'Hello' } },
-        { onError: error => error.message }
-    );
-    useUpdateMany<{ id: number; title: string }>('posts', undefined, {
-        onError: error => error.message,
-        onSettled: (_data, error) => error?.message,
-    });
-};

--- a/packages/ra-core/src/dataProvider/useUpdateMany.ts
+++ b/packages/ra-core/src/dataProvider/useUpdateMany.ts
@@ -77,7 +77,7 @@ import { useEvent } from '../util';
  */
 export const useUpdateMany = <
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
 >(
     resource?: string,
     params: Partial<UpdateManyParams<Partial<RecordType>>> = {},
@@ -303,7 +303,7 @@ export interface UseUpdateManyMutateParams<RecordType extends RaRecord = any> {
 
 export type UseUpdateManyOptions<
     RecordType extends RaRecord = any,
-    MutationError = Error,
+    MutationError = unknown,
 > = Omit<
     UseMutationOptions<
         Array<RecordType['id']>,
@@ -330,7 +330,7 @@ export type UseUpdateManyOptions<
 export type UseUpdateManyResult<
     RecordType extends RaRecord = any,
     TReturnPromise extends boolean = boolean,
-    MutationError = Error,
+    MutationError = unknown,
 > = [
     (
         resource?: string,

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithConfirmButton.tsx
@@ -162,7 +162,7 @@ const sanitizeRestProps = ({
 
 export interface BulkDeleteWithConfirmButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends ButtonProps,
         UseBulkDeleteControllerParams<RecordType, MutationOptionsError> {
     confirmContent?: React.ReactNode;

--- a/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkDeleteWithUndoButton.tsx
@@ -64,7 +64,7 @@ const sanitizeRestProps = ({
 
 export interface BulkDeleteWithUndoButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends ButtonProps,
         Omit<
             UseBulkDeleteControllerParams<RecordType, MutationOptionsError>,

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithConfirmButton.tsx
@@ -156,7 +156,7 @@ const sanitizeRestProps = ({
 
 export interface BulkUpdateWithConfirmButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends Omit<ButtonProps, 'onError'>,
         UseBulkUpdateControllerParams<RecordType, MutationOptionsError> {
     confirmContent?: React.ReactNode;

--- a/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/BulkUpdateWithUndoButton.tsx
@@ -66,7 +66,7 @@ const sanitizeRestProps = ({
 
 export interface BulkUpdateWithUndoButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends Omit<ButtonProps, 'onError'>,
         Omit<
             UseBulkUpdateControllerParams<RecordType, MutationOptionsError>,

--- a/packages/ra-ui-materialui/src/button/DeleteButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteButton.tsx
@@ -102,7 +102,7 @@ export const DeleteButton = React.forwardRef(function DeleteButton<
 
 export type DeleteButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > = SaveContextValue &
     (
         | ({ mutationMode?: 'undoable' } & DeleteWithUndoButtonProps<

--- a/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithConfirmButton.tsx
@@ -225,7 +225,7 @@ const defaultIcon = <ActionDelete />;
 
 export interface DeleteWithConfirmButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends ButtonProps,
         UseDeleteControllerParams<RecordType, MutationOptionsError> {
     confirmTitle?: React.ReactNode;

--- a/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/DeleteWithUndoButton.tsx
@@ -117,7 +117,7 @@ const defaultIcon = <ActionDelete />;
 
 export interface DeleteWithUndoButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends ButtonProps,
         UseDeleteControllerParams<RecordType, MutationOptionsError> {
     icon?: ReactNode;

--- a/packages/ra-ui-materialui/src/button/SaveButton.tsx
+++ b/packages/ra-ui-materialui/src/button/SaveButton.tsx
@@ -173,7 +173,7 @@ const defaultIcon = <ContentSave />;
 
 interface Props<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > {
     className?: string;
     disabled?: boolean;

--- a/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
+++ b/packages/ra-ui-materialui/src/button/UpdateWithUndoButton.tsx
@@ -106,7 +106,7 @@ const sanitizeRestProps = ({
 
 export interface UpdateWithUndoButtonProps<
     RecordType extends RaRecord = any,
-    MutationOptionsError = Error,
+    MutationOptionsError = unknown,
 > extends ButtonProps,
         Omit<
             UseUpdateControllerParams<RecordType, MutationOptionsError>,


### PR DESCRIPTION
Reverts marmelab/react-admin#11322, which causes compilation failures in projects using react-admin. 