### PR TITLE
Mark inputs with a required() validator as aria-required

### DIFF
--- a/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
+++ b/packages/ra-ui-materialui/src/input/ResettableTextField.tsx
@@ -40,6 +40,8 @@ export const ResettableTextField = forwardRef(
             variant,
             margin,
             className,
+            'aria-required': ariaRequired,
+            inputProps: htmlInputPropsFromConsumer,
             ...rest
         } = props;
 
@@ -159,11 +161,36 @@ export const ResettableTextField = forwardRef(
             ...InputPropsWithoutEndAdornment,
         };
 
+        // Props forwarded to the native <input> element. We translate the
+        // `aria-required` prop here (rather than forwarding the native
+        // `required` attribute) because react-admin relies on JS validation,
+        // not the browser's native validation. This marks inputs with a
+        // `required()` validator as required for assistive technologies
+        // without triggering native browser validation. See issue #9585.
+        const htmlInputProps = {
+            ...htmlInputPropsFromConsumer,
+            ...(ariaRequired ? { 'aria-required': true } : {}),
+        };
+        const hasHtmlInputProps = Object.keys(htmlInputProps).length > 0;
+
+        // @ts-expect-error slotProps do not yet exist in MUI v5
+        const htmlInputSlot = rest.slotProps?.htmlInput;
+        // slotProps.htmlInput may be an object or, in MUI v6+, a callback
+        // receiving the owner state. Preserve the caller's form when merging.
+        const mergedHtmlInputSlot =
+            typeof htmlInputSlot === 'function'
+                ? ownerState => ({
+                      ...htmlInputProps,
+                      ...htmlInputSlot(ownerState),
+                  })
+                : { ...htmlInputProps, ...htmlInputSlot };
+
         const mergedSlotProps = {
             // @ts-expect-error slotProps do not yet exist in MUI v5
             ...rest.slotProps,
             // @ts-expect-error slotProps do not yet exist in MUI v5
             input: { ...inputProps, ...rest.slotProps?.input },
+            ...(hasHtmlInputProps ? { htmlInput: mergedHtmlInputSlot } : {}),
         };
 
         return (
@@ -175,7 +202,11 @@ export const ResettableTextField = forwardRef(
                 margin={margin}
                 className={className}
                 {...rest}
-                {...(muiMajor >= 6 ? { slotProps: mergedSlotProps } : {})}
+                {...(muiMajor >= 6
+                    ? { slotProps: mergedSlotProps }
+                    : hasHtmlInputProps
+                      ? { inputProps: htmlInputProps }
+                      : {})}
                 inputRef={ref}
             />
         );

--- a/packages/ra-ui-materialui/src/input/TextInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.spec.tsx
@@ -123,6 +123,67 @@ describe('<TextInput />', () => {
         });
     });
 
+    describe('aria-required', () => {
+        it('should mark the input as required with aria-required (not the native required attribute) when a required() validator is set', () => {
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <ResourceContextProvider value="posts">
+                        <SimpleForm onSubmit={jest.fn}>
+                            <TextInput
+                                {...defaultProps}
+                                validate={required()}
+                            />
+                        </SimpleForm>
+                    </ResourceContextProvider>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText(
+                'resources.posts.fields.title *'
+            );
+            expect(input).toBeRequired();
+            expect(input).toHaveAttribute('aria-required', 'true');
+            // react-admin uses JS validation, so the native required attribute
+            // must not be set (it would trigger native browser validation).
+            expect(input).not.toHaveAttribute('required');
+        });
+
+        it('should not mark the input as required when no required validator is set', () => {
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <ResourceContextProvider value="posts">
+                        <SimpleForm onSubmit={jest.fn}>
+                            <TextInput {...defaultProps} />
+                        </SimpleForm>
+                    </ResourceContextProvider>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText('resources.posts.fields.title');
+            expect(input).not.toBeRequired();
+            expect(input).not.toHaveAttribute('aria-required');
+        });
+
+        it('should preserve caller-provided inputProps while adding aria-required', () => {
+            render(
+                <AdminContext dataProvider={testDataProvider()}>
+                    <ResourceContextProvider value="posts">
+                        <SimpleForm onSubmit={jest.fn}>
+                            <TextInput
+                                {...defaultProps}
+                                validate={required()}
+                                inputProps={{ 'data-custom': 'kept' }}
+                            />
+                        </SimpleForm>
+                    </ResourceContextProvider>
+                </AdminContext>
+            );
+            const input = screen.getByLabelText(
+                'resources.posts.fields.title *'
+            );
+            expect(input).toHaveAttribute('aria-required', 'true');
+            expect(input).toHaveAttribute('data-custom', 'kept');
+        });
+    });
+
     it('should keep null values', async () => {
         const onSuccess = jest.fn();
         render(<ValueNull onSuccess={onSuccess} />);

--- a/packages/ra-ui-materialui/src/input/TextInput.tsx
+++ b/packages/ra-ui-materialui/src/input/TextInput.tsx
@@ -71,6 +71,7 @@ export const TextInput = (props: TextInputProps) => {
         <StyledResettableTextField
             id={id}
             {...field}
+            aria-required={isRequired || undefined}
             className={clsx('ra-input', `ra-input-${source}`, className)}
             label={
                 label !== '' && label !== false ? (


### PR DESCRIPTION
## Problem

When an input uses a `required()` validator (e.g. `<TextInput source="id" validate={required()} />`), react-admin adds the `*` to the label but leaves the underlying `<input>` without any required semantics. As a result:

- Assistive technologies do not announce the field as required.
- Tests can't assert it: `expect(within(edit).getByLabelText('Id *')).toBeRequired()` fails.

This was reported in #9585. As discussed there, the fix should use `aria-required="true"` rather than the native `required` attribute: react-admin relies on JS validation, and forms render with `noValidate=false` by default, so a native `required` attribute would trigger native browser validation. Adding `aria-required` was the explicit direction given by the maintainer on the issue.

## Solution

Route an `aria-required` flag through the shared `ResettableTextField` renderer onto the native `<input>` element, and have `TextInput` pass `aria-required={isRequired || undefined}` (where `isRequired` already reflects the presence of a `required()` validator or the `isRequired` prop).

- The value is applied to the html-input slot only, handling both MUI v5 (`inputProps`) and MUI v6+ (`slotProps.htmlInput`, including the callback form).
- Caller-supplied `inputProps` / `slotProps.htmlInput` are preserved (non-lossy merge).
- Strictly a no-op when the input is not required (no attribute is added).
- The native `required` attribute is intentionally **not** set, so JS validation and label behavior are unchanged.

Scope: this PR fixes the reported `TextInput` case via the shared `ResettableTextField`. The same one-line `aria-required={isRequired || undefined}` wiring can be extended to the other inputs that expose `isRequired` (SelectInput, NumberInput, DateInput, …) — happy to widen this PR or open a follow-up, whichever the maintainers prefer.

## How To Test

`<TextInput source="id" validate={required()} />` now renders `<input ... aria-required="true">` (and still no native `required`). A non-required input is unchanged.

Unit test added in `TextInput.spec.tsx`:

```
describe('aria-required', () => {
  it('should mark the input as required with aria-required (not the native required attribute) when a required() validator is set', ...)
  it('should not mark the input as required when no required validator is set', ...)
  it('should preserve caller-provided inputProps while adding aria-required', ...)
})
```

## Test verification (RED → GREEN)

RED — on the unmodified `next` branch (test kept, production change reverted):

```
aria-required
  ✕ should mark the input as required with aria-required (not the native required attribute) when a required() validator is set
  ✓ should not mark the input as required when no required validator is set
  ✕ should preserve caller-provided inputProps while adding aria-required

  ● should mark the input as required ... › expect(element).toBeRequired()
    Received element is not required:
      <input aria-describedby=":r0:-helper-text" aria-invalid="false" id=":r0:" name="title" type="text" value="" />

Tests: 2 failed, 12 skipped, 1 passed, 15 total
```

GREEN — with the fix:

```
aria-required
  ✓ should mark the input as required with aria-required (not the native required attribute) when a required() validator is set
  ✓ should not mark the input as required when no required validator is set
  ✓ should preserve caller-provided inputProps while adding aria-required

Tests: 82 passed, 82 total
```

No regression across the shared renderer's consumers (`TextInput`, `SelectInput`, `NumberInput` suites all green); ESLint, Prettier, and the `ra-core` → `ra-ui-materialui` build all pass.

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature — targets `next` as requested on the issue.
- [x] The PR includes **unit tests**.
- [ ] The PR includes one or several **stories** — no new story: `aria-required` is a non-visual accessibility attribute and existing `required` stories (`TextInput.stories.tsx`, `useInput.stories.tsx`) already cover the required rendering. Happy to add one if preferred.
- [x] The **documentation** is up to date — the docs already recommend the `aria-required={isRequired}` pattern (`docs_headless/.../Inputs.md`, `useInput.md`); this makes the built-in `TextInput` conform, so no doc file drifts.
