### PR TITLE
[TypeScript] Add missing ra.validation.unique to TranslationMessages

### DIFF
--- a/packages/ra-core/src/i18n/TranslationMessages.ts
+++ b/packages/ra-core/src/i18n/TranslationMessages.ts
@@ -182,6 +182,7 @@ export interface TranslationMessages extends StringMap {
             email: string;
             oneOf: string;
             regex: string;
+            unique: string;
         };
         saved_queries: {
             label: string;


### PR DESCRIPTION
## Problem

`TranslationMessages` does not declare `ra.validation.unique`, even though react-admin emits that message key and `ra-language-english` ships it.

- `useUnique` returns `{ message: 'ra.validation.unique' }` ([`packages/ra-core/src/form/validation/useUnique.ts#L82`](https://github.com/marmelab/react-admin/blob/master/packages/ra-core/src/form/validation/useUnique.ts#L82))
- `ra-language-english` and `ra-language-french` both define it
- `TranslationMessages['ra']['validation']` does not

## Solution

Declare `unique: string` in `ra.validation`, in the same position as in `ra-language-english`.

## How To Test

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- [x] The PR includes one or several **stories** (if not possible, describe why)
- [x] The **documentation** is up to date

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
