### PR TITLE
Add aria-sort to sorted DataTable column headers

### DIFF
--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
@@ -102,6 +102,36 @@ describe('DataTable', () => {
                 );
             });
         });
+        it('should set aria-sort on the currently sorted column header', async () => {
+            render(<Basic />);
+            const headers = await screen.findAllByRole('columnheader');
+            // Basic sorts by id ascending by default
+            expect(headers[1].getAttribute('aria-sort')).toEqual('ascending');
+            // a column that is not the sort column has no aria-sort
+            expect(headers[2].getAttribute('aria-sort')).toBeNull();
+        });
+        it('should update aria-sort when the sort order changes', async () => {
+            render(<Basic />);
+            const headers = await screen.findAllByRole('columnheader');
+            // clicking the active ascending column switches it to descending
+            fireEvent.click(headers[1].firstChild as HTMLElement);
+            await waitFor(() => {
+                expect(headers[1].getAttribute('aria-sort')).toEqual(
+                    'descending'
+                );
+            });
+        });
+        it('should move aria-sort to the newly sorted column', async () => {
+            render(<Basic />);
+            const headers = await screen.findAllByRole('columnheader');
+            fireEvent.click(headers[2].firstChild as HTMLElement);
+            await waitFor(() => {
+                expect(headers[2].getAttribute('aria-sort')).toEqual(
+                    'ascending'
+                );
+            });
+            expect(headers[1].getAttribute('aria-sort')).toBeNull();
+        });
     });
     describe('Columns', () => {
         it('should render children as column headers', async () => {

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableHeadCell.tsx
@@ -93,6 +93,13 @@ export const DataTableHeadCell = React.memo(
                         `column-${source}`
                     )}
                     variant="head"
+                    sortDirection={
+                        sort && sort.field === source
+                            ? sort.order === 'ASC'
+                                ? 'asc'
+                                : 'desc'
+                            : false
+                    }
                     {...rest}
                 >
                     {handleSort && sort && !disableSort && source ? (


### PR DESCRIPTION
## Problem

DataTable column headers did not expose the current sort state to
assistive technology. There was no `aria-sort` on any `<th>`, so a
screen reader user could not tell which column the table was sorted by,
or in which direction.

This is a distinct, self-found gap in the sortable headers. It is
related to the maintainer-confirmed screen-reader/table-semantics
discussion in #11108, but that issue is about clickable rows, not the
column-header sort state — so this PR does not close it.

## Solution

Pass the active sort direction to the MUI `TableCell` through its
`sortDirection` prop. MUI maps that prop to `aria-sort="ascending"` or
`aria-sort="descending"` on the `<th>` element.

Only the currently sorted column receives `aria-sort`; other columns get
none, which matches the ARIA spec. The change is one prop on
`DataTableHeadCell`; no visual change.

## How To Test

From the repo root:

```sh
yarn install
LANG=en_US.UTF-8 NODE_ENV=test BABEL_ENV=cjs NODE_ICU_DATA=./node_modules/full-icu \
  node_modules/.bin/jest packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
```

The three new tests under `DataTable > Sorting` fail on `master` and pass
with this change. Manual: open any DataTable, turn on a screen reader,
and confirm the sorted column announces "sorted ascending/descending".

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (3 new tests in `DataTable.spec.tsx`)
- [ ] The PR includes one or several **stories** — not needed: this is an a11y fix to existing behaviour, covered by the existing `Basic` DataTable story the new tests render.
- [ ] The **documentation** is up to date — no doc change: `aria-sort` is internal behaviour with no public API change.

## Checks run locally

- Tests: PASS — `DataTable.spec.tsx` 30 passed (3 new); `list/datatable` folder 34 passed
- Lint (eslint): PASS on the two changed files (+ husky lint-staged on commit)
- Prettier: PASS on the two changed files
- Build/typecheck (`lerna run build` for ra-ui-materialui + deps): PASS

## Scope

One logical change: `aria-sort` on the modern `DataTable` header cell + its
tests. The legacy `Datagrid` (`DatagridHeaderCell`) has the same gap; left
for a separate follow-up PR to keep this one reviewable.

## AI disclosure

Drafted with AI assistance. I found the gap, wrote the failing tests
first to prove it, verified the fix makes them pass, and reviewed the
diff line by line. marmelab/react-admin does not require an AI-disclosure;
included here as good practice.

## Promotion note (fork-staged)

This PR is staged inside the fork (`olitreadwell/react-admin`, base
`master`). To open it upstream:

```sh
gh pr create --repo marmelab/react-admin --base master \
  --head olitreadwell:contrib/marmelab-react-admin-20260805-110228
```

No CLA, DCO, or signed commits are required by CONTRIBUTING. Consider
referencing #11108 (related table-a11y discussion) when promoting.