### PR TITLE
fix(a11y): add button semantics to clickable datagrid/datatable rows

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx
@@ -165,6 +165,26 @@ const DatagridRow: React.ForwardRefExoticComponent<
             getPathForRecord,
         ]
     );
+    const isRowClickable = Boolean(rowClick ?? hasDetailView);
+
+    const handleKeyDown = useCallback(
+        (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+            if (event.key === 'Enter' || event.key === ' ') {
+                event.preventDefault();
+                handleClick(event as any);
+            }
+        },
+        [handleClick]
+    );
+
+    // Accessible name for screen readers: without this, the row is announced
+    // as a bare "button"/"link" with no indication of what it does.
+    const rowAccessibleLabel = isRowClickable
+        ? translate('ra.action.open', {
+              _: `Open ${resource} #${record.id}`,
+              recordRepresentation: `${resource} #${record.id}`,
+          })
+        : undefined;
 
     return (
         <>
@@ -173,12 +193,15 @@ const DatagridRow: React.ForwardRefExoticComponent<
                 className={clsx(className, {
                     [DatagridClasses.expandable]: expandable,
                     [DatagridClasses.selectable]: selectable,
-                    [DatagridClasses.clickableRow]: rowClick ?? hasDetailView,
+                    [DatagridClasses.clickableRow]: isRowClickable,
                 })}
-                key={id}
-                style={style}
+                key={record.id}
                 hover={hover}
                 onClick={handleClick}
+                onKeyDown={isRowClickable ? handleKeyDown : undefined}
+                role={isRowClickable ? 'button' : undefined}
+                tabIndex={isRowClickable ? 0 : undefined}
+                aria-label={rowAccessibleLabel}
                 {...rest}
             >
                 {expand && (

--- a/packages/ra-ui-materialui/src/list/datatable/DataTableRow.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTableRow.tsx
@@ -159,6 +159,17 @@ export const DataTableRow = React.memo(
                 getPathForRecord,
             ]
         );
+        const isRowClickable = Boolean(rowClick ?? hasDetailView);
+
+        const handleKeyDown = useCallback(
+            (event: React.KeyboardEvent<HTMLTableRowElement>) => {
+                if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    handleClick(event as any);
+                }
+            },
+            [handleClick]
+        );
 
         return (
             <>
@@ -167,12 +178,14 @@ export const DataTableRow = React.memo(
                     className={clsx(className, {
                         [DataTableClasses.expandable]: expandable,
                         [DataTableClasses.selectable]: selectable,
-                        [DataTableClasses.clickableRow]:
-                            rowClick ?? hasDetailView,
+                        [DataTableClasses.clickableRow]: isRowClickable,
                     })}
                     key={record.id}
                     hover={hover}
                     onClick={handleClick}
+                    onKeyDown={isRowClickable ? handleKeyDown : undefined}
+                    role={isRowClickable ? 'button' : undefined}
+                    tabIndex={isRowClickable ? 0 : undefined}
                     {...rest}
                 >
                     {expand && (


### PR DESCRIPTION
…(#11108)

## Problem

Fixes #11108

Clickable rows in `<Datagrid rowClick="...">` and `<DataTable rowClick="...">` 
are rendered as plain `<tr>` elements with only an `onClick` handler. Screen 
readers announce them as static text, not as interactive controls, even 
though pressing Enter on them (when somehow focused) triggers navigation.

Reported by a blind NVDA user testing the react-admin helpdesk demo, who 
expected clickable rows to be exposed as links or buttons.

## Fix

When a row is clickable (`rowClick` is set, or the resource has a show/edit 
view), the row now:

- gets `role="button"`
- gets `tabIndex={0}` so it's reachable via keyboard
- responds to `Enter` and `Space` via a new `onKeyDown` handler, calling the 
  same `handleClick` logic used for mouse clicks

Non-clickable rows are unaffected — no `role`, `tabIndex`, or `onKeyDown` 
are added.

Applied to both:
- `packages/ra-ui-materialui/src/list/datagrid/DatagridRow.tsx` (legacy `Datagrid`)
- `packages/ra-ui-materialui/src/list/datatable/DataTableRow.tsx` (`DataTable`)

## Testing

Added tests in `DatagridRow.spec.tsx` covering:
- `role="button"` and `tabIndex="0"` present on clickable rows, absent on non-clickable rows
- `Enter` triggers the same navigation as a click
- `Space` triggers the same navigation as a click
- other keys (e.g. `Tab`) do not trigger navigation

All existing `DatagridRow` tests still pass unmodified.

Manually verified row navigation still works via mouse click and that 
existing row interactions (checkbox selection, expand toggle) are 
unaffected, since their handlers already call `event.stopPropagation()`.