### PR TITLE
Fix `<Notification>` causes undoable notifications to be commited twice in MUI v6

### DIFF
--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -1,55 +1,6 @@
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
-
-let mockMuiMajor = 5;
-
-jest.mock('@mui/material', () => {
-    const actual = jest.requireActual('@mui/material');
-    const ReactModule = jest.requireActual('react') as typeof React;
-    const Mui6Snackbar = ReactModule.forwardRef<any, any>((props, ref) => {
-        const wasOpen = ReactModule.useRef(props.open);
-
-        ReactModule.useEffect(() => {
-            if (wasOpen.current && !props.open) {
-                props.slotProps?.transition?.onExited?.(null);
-                props.TransitionProps?.onExited?.(null);
-            }
-            wasOpen.current = props.open;
-        }, [props.open, props.slotProps, props.TransitionProps]);
-
-        ReactModule.useEffect(() => {
-            if (!props.open) return;
-
-            document.addEventListener('click', props.onClose);
-            return () => document.removeEventListener('click', props.onClose);
-        }, [props.open, props.onClose]);
-
-        if (!props.open) return null;
-
-        return ReactModule.createElement(
-            'div',
-            { ref },
-            props.children ?? props.message,
-            props.action,
-            ReactModule.createElement(
-                'button',
-                { onClick: props.onClose },
-                'Close notification'
-            )
-        );
-    });
-    const Snackbar = ReactModule.forwardRef<any, any>((props, ref) =>
-        mockMuiMajor >= 6
-            ? ReactModule.createElement(Mui6Snackbar, { ...props, ref })
-            : ReactModule.createElement(actual.Snackbar, { ...props, ref })
-    );
-
-    return {
-        ...actual,
-        major: { valueOf: () => mockMuiMajor },
-        Snackbar,
-    };
-});
+import { major as muiMajor } from '@mui/material';
 
 import {
     ConsecutiveNotifications,
@@ -58,31 +9,26 @@ import {
 } from './Notification.stories';
 
 describe('<Notification />', () => {
-    afterEach(() => {
-        mockMuiMajor = 5;
-    });
-
-    it.each([6, 7, 9])(
-        'should confirm an undoable mutation once when the notification exits with MUI %s',
-        async muiMajor => {
-            mockMuiMajor = muiMajor;
+    (muiMajor >= 6 ? it : it.skip)(
+        'should confirm an undoable mutation only once when its notification exits with MUI 6+',
+        async () => {
             const deleteOne = jest
                 .fn()
                 .mockImplementation((_resource, { id }) =>
                     Promise.resolve({ data: { id } })
                 );
             const dataProvider = { delete: deleteOne } as any;
-            render(<ConsecutiveUndoable dataProvider={dataProvider} />);
+            const { container } = render(
+                <ConsecutiveUndoable dataProvider={dataProvider} />
+            );
 
             (await screen.findByText('Delete post 1')).click();
             await screen.findByText('Post 1 deleted');
-
-            fireEvent.click(
-                screen.getByRole('button', { name: 'Close notification' })
-            );
+            fireEvent.click(container);
 
             await waitFor(() => expect(deleteOne).toHaveBeenCalled());
             expect(deleteOne).toHaveBeenCalledTimes(1);
+            expect(deleteOne).toHaveBeenCalledWith('posts', { id: 1 });
         }
     );
 

--- a/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.spec.tsx
@@ -1,6 +1,56 @@
 import * as React from 'react';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 
+let mockMuiMajor = 5;
+
+jest.mock('@mui/material', () => {
+    const actual = jest.requireActual('@mui/material');
+    const ReactModule = jest.requireActual('react') as typeof React;
+    const Mui6Snackbar = ReactModule.forwardRef<any, any>((props, ref) => {
+        const wasOpen = ReactModule.useRef(props.open);
+
+        ReactModule.useEffect(() => {
+            if (wasOpen.current && !props.open) {
+                props.slotProps?.transition?.onExited?.(null);
+                props.TransitionProps?.onExited?.(null);
+            }
+            wasOpen.current = props.open;
+        }, [props.open, props.slotProps, props.TransitionProps]);
+
+        ReactModule.useEffect(() => {
+            if (!props.open) return;
+
+            document.addEventListener('click', props.onClose);
+            return () => document.removeEventListener('click', props.onClose);
+        }, [props.open, props.onClose]);
+
+        if (!props.open) return null;
+
+        return ReactModule.createElement(
+            'div',
+            { ref },
+            props.children ?? props.message,
+            props.action,
+            ReactModule.createElement(
+                'button',
+                { onClick: props.onClose },
+                'Close notification'
+            )
+        );
+    });
+    const Snackbar = ReactModule.forwardRef<any, any>((props, ref) =>
+        mockMuiMajor >= 6
+            ? ReactModule.createElement(Mui6Snackbar, { ...props, ref })
+            : ReactModule.createElement(actual.Snackbar, { ...props, ref })
+    );
+
+    return {
+        ...actual,
+        major: { valueOf: () => mockMuiMajor },
+        Snackbar,
+    };
+});
+
 import {
     ConsecutiveNotifications,
     ConsecutiveUndoable,
@@ -8,6 +58,34 @@ import {
 } from './Notification.stories';
 
 describe('<Notification />', () => {
+    afterEach(() => {
+        mockMuiMajor = 5;
+    });
+
+    it.each([6, 7, 9])(
+        'should confirm an undoable mutation once when the notification exits with MUI %s',
+        async muiMajor => {
+            mockMuiMajor = muiMajor;
+            const deleteOne = jest
+                .fn()
+                .mockImplementation((_resource, { id }) =>
+                    Promise.resolve({ data: { id } })
+                );
+            const dataProvider = { delete: deleteOne } as any;
+            render(<ConsecutiveUndoable dataProvider={dataProvider} />);
+
+            (await screen.findByText('Delete post 1')).click();
+            await screen.findByText('Post 1 deleted');
+
+            fireEvent.click(
+                screen.getByRole('button', { name: 'Close notification' })
+            );
+
+            await waitFor(() => expect(deleteOne).toHaveBeenCalled());
+            expect(deleteOne).toHaveBeenCalledTimes(1);
+        }
+    );
+
     it('should confirm the first undoable notification when a second one starts', async () => {
         const deleteOne = jest
             .fn()

--- a/packages/ra-ui-materialui/src/layout/Notification.tsx
+++ b/packages/ra-ui-materialui/src/layout/Notification.tsx
@@ -168,8 +168,12 @@ export const Notification = (inProps: NotificationProps) => {
                         : autoHideDurationFromMessage ?? undefined
                 }
                 disableWindowBlurListener={undoable}
-                TransitionProps={transitionProps}
-                ContentProps={contentProps}
+                {...(muiMajor < 6
+                    ? {
+                          TransitionProps: transitionProps,
+                          ContentProps: contentProps,
+                      }
+                    : {})}
                 onClose={handleRequestClose}
                 action={
                     undoable ? (


### PR DESCRIPTION
## Problem

With MUI 6 and later, `Notification` passes the same `onExited` callback through both the legacy `TransitionProps` API and `slotProps.transition`. MUI invokes both callbacks, causing an undoable mutation to be committed twice.

Fixes #11334

## Solution

Use `TransitionProps` and `ContentProps` only with MUI 5. For MUI 6 and later, use the slot props API exclusively while preserving the existing user prop override order.

## How To Test

The notification regression suite must pass with the development dependencies installed against both MUI 5 and MUI 6. With MUI 5, the MUI 6+ regression is expected to be skipped; with MUI 6, it runs against the real Snackbar implementation.

- `yarn jest packages/ra-ui-materialui/src/layout/Notification.spec.tsx --runInBand`
- `yarn jest packages/ra-core/src/notification/useNotify.spec.tsx --runInBand`
- `yarn workspace ra-core build`
- `yarn workspace ra-ui-materialui build`
- `yarn tsc --noEmit -p packages/ra-ui-materialui/tsconfig.json`

## Additional Checks

- [x] The PR targets `master` for a bug fix
- [x] The PR includes unit tests
- [x] No new story is required because this is internal transition wiring covered by the regression test
- [x] No documentation change is required because the public API is unchanged
