### PR TITLE
Fix `<DataTable>` calls `useCanAccess` even when bulk delete is disabled

### DIFF
--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
@@ -1,6 +1,11 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import * as React from 'react';
 import {
+    ResourceContextProvider,
+    TestMemoryRouter,
+    type AuthProvider,
+} from 'ra-core';
+import {
     Basic,
     Columns,
     Empty,
@@ -12,6 +17,8 @@ import {
     StandaloneDynamic,
     StandaloneStatic,
 } from './DataTable.stories';
+import { DataTable } from './DataTable';
+import { AdminContext } from '../../AdminContext';
 
 describe('DataTable', () => {
     it('should render one row per record in the list', async () => {
@@ -218,6 +225,39 @@ describe('DataTable', () => {
         });
     });
     describe('bulkActionButtons', () => {
+        it('should not check delete permissions when bulk actions are disabled', () => {
+            const authProvider: AuthProvider = {
+                canAccess: jest.fn().mockResolvedValue(true),
+                checkAuth: jest.fn().mockResolvedValue(undefined),
+                checkError: jest.fn().mockResolvedValue(undefined),
+                getPermissions: jest.fn().mockResolvedValue(undefined),
+                login: jest.fn().mockResolvedValue(undefined),
+                logout: jest.fn().mockResolvedValue(undefined),
+            };
+
+            render(
+                <TestMemoryRouter>
+                    <AdminContext authProvider={authProvider}>
+                        <ResourceContextProvider value="books">
+                            <DataTable
+                                bulkActionButtons={false}
+                                data={[{ id: 1 }]}
+                                isPending={false}
+                                onSelect={jest.fn()}
+                                onToggleItem={jest.fn()}
+                                selectedIds={[]}
+                                total={1}
+                            >
+                                <DataTable.Col source="id" />
+                            </DataTable>
+                        </ResourceContextProvider>
+                    </AdminContext>
+                </TestMemoryRouter>
+            );
+
+            expect(authProvider.canAccess).not.toHaveBeenCalled();
+        });
+
         it('should reveal bulk delete button by default on row selection', async () => {
             render(<Basic />);
             const checkboxes = await screen.findAllByRole('checkbox');

--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.spec.tsx
@@ -1,4 +1,5 @@
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { QueryClient } from '@tanstack/react-query';
 import * as React from 'react';
 import {
     ResourceContextProvider,
@@ -225,6 +226,38 @@ describe('DataTable', () => {
         });
     });
     describe('bulkActionButtons', () => {
+        it('should not enable delete permission queries without an auth provider', async () => {
+            const queryClient = new QueryClient();
+
+            render(
+                <TestMemoryRouter>
+                    <AdminContext queryClient={queryClient}>
+                        <ResourceContextProvider value="books">
+                            <DataTable
+                                bulkActionsToolbar={<></>}
+                                data={[{ id: 1 }]}
+                                isPending={false}
+                                onSelect={jest.fn()}
+                                onToggleItem={jest.fn()}
+                                selectedIds={[]}
+                                total={1}
+                            >
+                                <DataTable.Col source="id" />
+                            </DataTable>
+                        </ResourceContextProvider>
+                    </AdminContext>
+                </TestMemoryRouter>
+            );
+
+            await waitFor(() => {
+                const [query] = queryClient.getQueryCache().findAll({
+                    queryKey: ['auth', 'canAccess'],
+                });
+                expect(query.state.fetchStatus).toBe('idle');
+                expect(query.state.data).toBeUndefined();
+            });
+        });
+
         it('should not check delete permissions when bulk actions are disabled', () => {
             const authProvider: AuthProvider = {
                 canAccess: jest.fn().mockResolvedValue(true),

--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.tsx
@@ -139,7 +139,7 @@ export const DataTable = React.forwardRef(function DataTable<
     const { canAccess: canDelete } = useCanAccess({
         resource: resourceFromContext,
         action: 'delete',
-        enabled: props.bulkActionButtons !== false,
+        ...(props.bulkActionButtons === false ? { enabled: false } : {}),
     });
 
     const {

--- a/packages/ra-ui-materialui/src/list/datatable/DataTable.tsx
+++ b/packages/ra-ui-materialui/src/list/datatable/DataTable.tsx
@@ -139,6 +139,7 @@ export const DataTable = React.forwardRef(function DataTable<
     const { canAccess: canDelete } = useCanAccess({
         resource: resourceFromContext,
         action: 'delete',
+        enabled: props.bulkActionButtons !== false,
     });
 
     const {


### PR DESCRIPTION
## Problem

DataTable always requests delete permission, even when bulkActionButtons is explicitly false. This causes an unnecessary authProvider.canAccess call and can pass a record from an unrelated context to the permission check.

## Solution

Disable the delete permission query when bulk actions are disabled. The default behavior and custom bulk action behavior remain unchanged.

## How To Test

Run the DataTable unit test suite. The added test renders DataTable with bulkActionButtons={false} and verifies that the auth provider is not called.

## Additional Checks

- [x] The PR targets master for a bugfix.
- [x] The PR includes unit tests.
- [ ] The PR includes a story (not applicable: this is an internal permission-query optimization with no new visual state).
- [x] The documentation is up to date; no public API or usage change was introduced.

Fixes #11346