### PR TITLE
Fix Datagrid delete permission check when bulk actions are disabled

### DIFF
--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx
@@ -12,6 +12,7 @@ import {
     ListContextProvider,
     useRecordContext,
     ResourceContextProvider,
+    AuthProvider,
 } from 'ra-core';
 import { ThemeProvider, createTheme } from '@mui/material';
 
@@ -28,9 +29,12 @@ const TitleField = () => {
     return <span>{record?.title}</span>;
 };
 
-const Wrapper = ({ children, listContext }) => (
+const Wrapper = ({ children, listContext, authProvider = undefined }) => (
     <ThemeProvider theme={createTheme()}>
-        <CoreAdminContext dataProvider={testDataProvider()}>
+        <CoreAdminContext
+            dataProvider={testDataProvider()}
+            authProvider={authProvider}
+        >
             <ResourceContextProvider value={listContext.resource}>
                 <ListContextProvider value={listContext}>
                     {children}
@@ -135,6 +139,27 @@ describe('<Datagrid />', () => {
         render(<SelectAllButton onlyDisplay="disabled" />);
         fireEvent.click(await screen.findByLabelText('ra.action.select_all'));
         expect(screen.queryByText('Select All')).toBeNull();
+    });
+
+    it('should not check delete permissions when bulk actions are disabled', () => {
+        const authProvider: AuthProvider = {
+            canAccess: jest.fn().mockResolvedValue(true),
+            checkAuth: jest.fn().mockResolvedValue(undefined),
+            checkError: jest.fn().mockResolvedValue(undefined),
+            getPermissions: jest.fn().mockResolvedValue(undefined),
+            login: jest.fn().mockResolvedValue(undefined),
+            logout: jest.fn().mockResolvedValue(undefined),
+        };
+
+        render(
+            <Wrapper listContext={contextValue} authProvider={authProvider}>
+                <Datagrid bulkActionButtons={false}>
+                    <TitleField />
+                </Datagrid>
+            </Wrapper>
+        );
+
+        expect(authProvider.canAccess).not.toHaveBeenCalled();
     });
 
     describe('row selection', () => {

--- a/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
+++ b/packages/ra-ui-materialui/src/list/datagrid/Datagrid.tsx
@@ -131,6 +131,7 @@ export const Datagrid: React.ForwardRefExoticComponent<
     const { canAccess: canDelete } = useCanAccess({
         resource: resourceFromContext,
         action: 'delete',
+        ...(props.bulkActionButtons === false ? { enabled: false } : {}),
     });
     const {
         optimized = false,


### PR DESCRIPTION
## Problem

`<Datagrid bulkActionButtons={false}>` still calls `authProvider.canAccess()` for delete permissions even though no bulk delete action can be rendered. This is the legacy Datagrid counterpart of #11346 / #11352.

## Solution

Disable the delete access query when bulk actions are explicitly disabled, using the same guarded `enabled: false` behavior as DataTable.

## How To Test

- `corepack yarn jest packages/ra-ui-materialui/src/list/datagrid/Datagrid.spec.tsx --runInBand` — 20 passed
- Prettier and ESLint on both changed files
- `corepack yarn lerna run build --scope ra-core --scope ra-ui-materialui --include-dependencies`
- `git diff --check`

## Additional Checks

- [x] Targets `master` as a bug fix
- [x] Includes a focused unit test
- [ ] Stories: not needed; no rendered behavior changes
- [x] Documentation remains accurate; no public API changes
