### PR TITLE
feat: Migrate useFormRootPath to ra-core

### DIFF
--- a/packages/ra-core/src/form/index.ts
+++ b/packages/ra-core/src/form/index.ts
@@ -12,3 +12,4 @@ export * from './validation';
 export * from './WarnWhenUnsavedChanges';
 export * from './FilterLiveForm';
 export * from './useFormIsDirty';
+export * from './useFormRootPath';

--- a/packages/ra-core/src/form/useFormRootPath.spec.tsx
+++ b/packages/ra-core/src/form/useFormRootPath.spec.tsx
@@ -1,0 +1,46 @@
+import * as React from 'react';
+import { render, screen } from '@testing-library/react';
+
+import { useFormRootPath } from './useFormRootPath';
+import { TestMemoryRouter } from '../routing';
+
+describe('useFormRootPath', () => {
+    const UseFormRootPath = () => <div>{`[${useFormRootPath()}]`}</div>;
+
+    const renderAt = (pathname: string) =>
+        render(
+            <TestMemoryRouter initialEntries={[pathname]}>
+                <UseFormRootPath />
+            </TestMemoryRouter>
+        );
+
+    it('returns the create form root path', async () => {
+        renderAt('/posts/create');
+
+        await screen.findByText('[/posts/create]');
+    });
+
+    it('returns the create form root path when on a tab', async () => {
+        renderAt('/posts/create/2');
+
+        await screen.findByText('[/posts/create]');
+    });
+
+    it('returns the edit form root path', async () => {
+        renderAt('/posts/123');
+
+        await screen.findByText('[/posts/123]');
+    });
+
+    it('returns the edit form root path when on a tab', async () => {
+        renderAt('/posts/123/2');
+
+        await screen.findByText('[/posts/123]');
+    });
+
+    it('returns an empty string when the location matches no form', async () => {
+        renderAt('/posts');
+
+        await screen.findByText('[]');
+    });
+});

--- a/packages/ra-core/src/form/useFormRootPath.ts
+++ b/packages/ra-core/src/form/useFormRootPath.ts
@@ -1,4 +1,4 @@
-import { useLocation, useMatchPath } from 'ra-core';
+import { useLocation, useMatchPath } from '../routing';
 
 /**
  * This hook infers the tabbed form root path from the current location.

--- a/packages/ra-ui-materialui/src/form/TabbedForm.tsx
+++ b/packages/ra-ui-materialui/src/form/TabbedForm.tsx
@@ -6,11 +6,16 @@ import {
     ReactNode,
     HtmlHTMLAttributes,
 } from 'react';
-import { Form, FormProps, MutationMode, RaRecord } from 'ra-core';
+import {
+    Form,
+    FormProps,
+    MutationMode,
+    RaRecord,
+    useFormRootPath,
+} from 'ra-core';
 import get from 'lodash/get.js';
 
 import { TabbedFormView, TabbedFormViewProps } from './TabbedFormView';
-import { useFormRootPath } from './useFormRootPath';
 import { FormTab } from './FormTab';
 
 /**


### PR DESCRIPTION
## Problem

The hook useFormRootPath is part of ra-ui-material-ui, yet it does not depends on any mui component, and shadcn-admin-kit could make use of this hook.

## Solution

Migrate useFormRootPath to ra-core

## Additional Checks

- [x] The PR targets `master` for a bugfix or a documentation fix, or `next` for a feature
- [x] The PR includes **unit tests** (if not possible, describe why)
- ~[ ] The PR includes one or several **stories** (if not possible, describe why)~
- ~[ ] The **documentation** is up to date~

Also, please make sure to read the [contributing guidelines](https://github.com/marmelab/react-admin#contributing).
