### PR TITLE
Fix AutocompleteInput clearing mouse selections on blur

### DIFF
--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -1212,6 +1212,18 @@ describe('<AutocompleteInput />', () => {
     });
 
     describe('onCreate', () => {
+        it('should keep a clicked choice on blur when autoSelect is enabled', async () => {
+            render(<OnCreate autoSelect autoHighlight />);
+            const input = (await screen.findByLabelText(
+                'Author'
+            )) as HTMLInputElement;
+
+            fireEvent.focus(input);
+            fireEvent.click(await screen.findByText('Victor Hugo'));
+            fireEvent.blur(input);
+
+            expect(input.value).toEqual('Victor Hugo');
+        });
         it("shouldn't include an option with the create label when the input is empty", async () => {
             render(<OnCreate />);
             const input = (await screen.findByLabelText(

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx
@@ -26,6 +26,7 @@ import {
     InsideReferenceInputOnChange,
     WithInputProps,
     OnCreate,
+    OnCreateWithAutoSelect,
     OnCreateSlow,
     CreateLabel,
     CreateItemLabel,
@@ -1213,7 +1214,7 @@ describe('<AutocompleteInput />', () => {
 
     describe('onCreate', () => {
         it('should keep a clicked choice on blur when autoSelect is enabled', async () => {
-            render(<OnCreate autoSelect autoHighlight />);
+            render(<OnCreateWithAutoSelect />);
             const input = (await screen.findByLabelText(
                 'Author'
             )) as HTMLInputElement;

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.stories.tsx
@@ -375,6 +375,12 @@ OnCreate.argTypes = {
     },
 };
 
+export const OnCreateWithAutoSelect = () => (
+    <Wrapper>
+        <OnCreateInput autoSelect autoHighlight />
+    </Wrapper>
+);
+
 const AutocompleteWithCreateInReferenceInput = () => {
     const [create] = useCreate();
     const handleCreateAuthor = async (authorName?: string) => {

--- a/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
+++ b/packages/ra-ui-materialui/src/input/AutocompleteInput.tsx
@@ -619,6 +619,13 @@ If you provided a React element for the optionText prop, you must also provide t
         (event: any, newValue: any, reason: AutocompleteChangeReason) => {
             // This prevents auto-submitting a form inside a dialog passed to the `create` prop
             event.preventDefault();
+            if (
+                reason === 'blur' &&
+                typeof newValue === 'string' &&
+                doesQueryMatchSelection(newValue)
+            ) {
+                return;
+            }
             if (reason === 'createOption') {
                 // When users press the enter key after typing a new value, we can handle it as if they clicked on the create option
                 handleChangeWithCreateSupport(
@@ -634,7 +641,12 @@ If you provided a React element for the optionText prop, you must also provide t
                 newValue != null ? newValue : emptyValue
             );
         },
-        [emptyValue, getCreateItem, handleChangeWithCreateSupport]
+        [
+            doesQueryMatchSelection,
+            emptyValue,
+            getCreateItem,
+            handleChangeWithCreateSupport,
+        ]
     );
 
     const oneSecondHasPassed = useTimeout(1000, filterValue);


### PR DESCRIPTION
## Problem

Fixes #9813.

When `AutocompleteInput` uses both `onCreate` and `autoSelect`, clicking an existing choice and then blurring the input clears the selection. MUI emits the selected label again as a free-solo string during blur, and the string has no choice id.

## Solution

Ignore that duplicate blur change only when its string already matches the selected choice. Unmatched free-solo values and normal choice changes keep their existing behavior.

## How To Test

- `corepack yarn jest packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx --runInBand` — 75 tests passed
- `corepack yarn eslint packages/ra-ui-materialui/src/input/AutocompleteInput.tsx packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx` — passed
- `./node_modules/.bin/prettier --config ./.prettierrc.js --check packages/ra-ui-materialui/src/input/AutocompleteInput.tsx packages/ra-ui-materialui/src/input/AutocompleteInput.spec.tsx` — passed
- `corepack yarn workspace ra-ui-materialui build` — passed

## Additional Checks

- [x] The PR targets `master` for a bugfix
- [x] The PR includes a regression test
- [ ] No new story is needed; the regression uses the existing `OnCreate` story
- [x] No documentation change is needed; the public API is unchanged
