### PR TITLE
[Docs] Fix custom field uses defaultProps for labels

### DIFF
--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -499,7 +499,7 @@ export const FullNameField = (props) => {
 
 **Tip**: Always check the `record` is defined before inspecting its properties, as react-admin may display the Show view *before* fetching the record from the data provider. So the first time it renders the show view for a resource, the `record` is `undefined`.
 
-You can now use this field like any other react-admin field. Pass the `label` explicitly so the parent layout can read it from the field's props. A default parameter inside `FullNameField` would not be visible to the parent layout, and React 19 no longer supports `defaultProps` for function components:
+You can now use this field like any other react-admin field. Pass the `label` explicitly so the parent layout can read it from the field's props:
 
 ```jsx
 import { List, Datagrid } from 'react-admin';

--- a/docs/Fields.md
+++ b/docs/Fields.md
@@ -495,13 +495,11 @@ export const FullNameField = (props) => {
     const record = useRecordContext(props);
     return record ? <span>{record.firstName} {record.lastName}</span> : null;
 }
-
-FullNameField.defaultProps = { label: 'Name' };
 ```
 
 **Tip**: Always check the `record` is defined before inspecting its properties, as react-admin may display the Show view *before* fetching the record from the data provider. So the first time it renders the show view for a resource, the `record` is `undefined`.
 
-You can now use this field like any other react-admin field:
+You can now use this field like any other react-admin field. Pass the `label` explicitly so the parent layout can read it from the field's props. A default parameter inside `FullNameField` would not be visible to the parent layout, and React 19 no longer supports `defaultProps` for function components:
 
 ```jsx
 import { List, Datagrid } from 'react-admin';
@@ -510,7 +508,7 @@ import { FullNameField } from './FullNameField';
 export const UserList = () => (
     <List>
         <Datagrid>
-            <FullNameField source="lastName" />
+            <FullNameField source="lastName" label="Name" />
         </Datagrid>
     </List>
 );


### PR DESCRIPTION
## Problem

The custom field example recommends function-component `defaultProps`, which React 19 no longer supports. Replacing it with a default function parameter would not expose the label to the parent layout.

Closes #10684.

## Solution

Pass `label="Name"` explicitly when using `FullNameField` and explain why the label belongs on the element. The existing Datagrid example and sorting source remain intact.

## How To Test

Reviewed the example against `DatagridHeaderCell` and `Labeled`, which read the label from the child element's props. `git diff --check` passes. Documentation build and browser rendering were not run.

## Additional Checks

- [x] Targets `master` for a documentation fix
- Unit tests and stories: not applicable; this changes only an existing documentation example
- [x] Documentation updated
